### PR TITLE
Change Domain Strategy

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -998,7 +998,7 @@ const getFragVLESSConfig = async (env, userID, hostName) => {
                 tag: "fragment",
                 protocol: "freedom",
                 settings: {
-                    domainStrategy: "AsIs",
+                    domainStrategy: "IPIfNonMatch",
                     fragment: {
                         packets: "tlshello",
                         length: `${lengthMin}-${lengthMax}`,
@@ -1141,7 +1141,7 @@ const getFragVLESSConfig = async (env, userID, hostName) => {
             {
                 protocol: "freedom",
                 settings: {
-                    domainStrategy: "AsIs",
+                    domainStrategy: "IPIfNonMatch",
                     fragment: {
                         length: `${lengthMin}-${lengthMax}`,
                         interval: `${intervalMin}-${intervalMax}`,


### PR DESCRIPTION
According to Xray documentation, "AsIs" routing doesn't consider IP rules, so the config doesn't exclude GeoIP:ir.
I changed the routing to "IPIfNonMatch" to solve this.
I hope this change is correct, because I am not familiar to worker codes.

Reference: https://www.v2ray.com/en/configuration/routing.html