### PR TITLE
Increase compatibility for new apps

### DIFF
--- a/_worker.js
+++ b/_worker.js
@@ -2614,7 +2614,7 @@ const buildDNSObject = async (remoteDNS, localDNS, blockAds, bypassIran, blockPo
           isWorkerLess ? "https://cloudflare-dns.com/dns-query" : remoteDNS,
           {
             address: localDNS,
-            domains: ["geosite:category-ir", "domain:.ir"],
+            domains: ["domain:.ir"],
             expectIPs: ["geoip:ir"],
             port: 53,
           },
@@ -2683,7 +2683,7 @@ const buildRoutingRules = (localDNS, blockAds, bypassIran, blockPorn, bypassLAN,
         
         if (bypassIran && !isWorkerLess) {
             rules.push({
-                domain: ["geosite:category-ir", "domain:.ir"],
+                domain: ["domain:.ir"],
                 outboundTag: "direct",
                 type: "field",
             });


### PR DESCRIPTION
سلام

لیست category-ir که برای مستقیم شدن قرار دادید، عمدتا دامنه های ir هستند. چون سازنده این لیست بیشتر تاکید داشت صرفا سایت های دولتی و بانک ها را قرار دهد که IP های خارج ایران را بلاک کردند و شرکت های دولتی و بانک ها همگی ir هستند (البته بعد از آن چند PR بوده که سایت های دیگه را اضافه کرده ولی کم بودند). با این حساب اگر این لیست را حذف کنید، کماکان ۹۰ درصد دامین های این لیست در گروه ir قرار میگیرند. از طرف دیگر مشکل فیلتر شدن از ترافیک خروجی هم در worker وجود ندارد و چیزی در سمت سرور بلاک نمی شود و کاربر در نهایت سایت های ایرانی را می تواند از طریق پروکسی ببیند. با این تغییر کاربر نهایی (کسی که ممکن است کانفیگ را از دوست خود گرفته یا کانفیگ دونیتی دریافت کرده و دانش فنی ندارد) لازم نیست اقدامی انجام دهد و می‌تواند صرفا با وارد کردن کانفیگ/سابسکریپشن، از آن استفاده کند.
میدانم این موضوع سلیقه ای است و ممکن است شما آن را نپسندید. اگر این ایده را پسندیدید خوشحال میشوم آن را تایید کنید

این موضوع را هم اضافه کنم که PR آپدیت کردن فایل geosite را در v2rayNG ثبت کردم که مالک پروژه به دلیل افزایش حجم فایل آن را رد کرد