### PR TITLE
[codex] Add macOS wizard installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,7 @@
 !src/**
 !scripts/
 !scripts/build.js
+!scripts/install-macos-wizard.sh
 !.github/
 !.github/**
 !README_fa.md

--- a/README.md
+++ b/README.md
@@ -48,6 +48,24 @@ This project is aimed to provide a user panel to access FREE, SECURE and PRIVATE
 - [How to use](https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/)
 - [FAQ](https://bia-pain-bache.github.io/BPB-Worker-Panel/faq/)
 
+### macOS quick install
+
+On macOS, you can install and launch the BPB Wizard directly from Terminal. The script detects Apple Silicon vs Intel Macs, downloads the correct Wizard build, installs or updates it, and runs it for you:
+
+```bash
+bash <(curl -fsSL https://raw.githubusercontent.com/bia-pain-bache/BPB-Worker-Panel/main/scripts/install-macos-wizard.sh)
+```
+
+### Subscription import tip
+
+After deployment, import the subscription URL from the panel into the matching client instead of creating a manual profile:
+
+- Xray clients: import the `?app=xray` subscription
+- Sing-box clients: import the `?app=sing-box` subscription
+- Clash/Mihomo clients: import the `?app=clash` subscription
+
+If you are testing for the first time, start with `Best Ping` or a `443` config.
+
 ## Supported Clients
 
 |       Client        |      Version      |  Fragment support  |  Warp Pro support  |

--- a/docs/en/docs/installation/wizard.md
+++ b/docs/en/docs/installation/wizard.md
@@ -13,13 +13,42 @@ To use this method, all you need is a Cloudflare account. You can [sign up here]
 !!! warning
     If you're connected to a VPN, disconnect it.
 
-### Windows - Linux - macOS
+### Windows
 
-Based on your operating system, [download the ZIP file](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest), unzip it, and run the program.
+Based on your system architecture, [download the ZIP file](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest), unzip it, and run the program.
 
-### Android
+!!! warning
+    The Wizard downloads `worker.js` from GitHub to customize and deploy it to your Cloudflare account. Because the binary is not code-signed, Windows Defender or other antivirus software may warn about it. Temporarily allow it if you trust the official release.
 
-Android users who have Termux installed on their phone can install the BPB Panel by just copying this code into Termux:
+### macOS
+
+The quickest way on macOS is to run this command in Terminal:
+
+```bash title="macOS - Apple Silicon and Intel"
+bash <(curl -fsSL https://raw.githubusercontent.com/bia-pain-bache/BPB-Worker-Panel/main/scripts/install-macos-wizard.sh)
+```
+
+It automatically detects whether your Mac is Apple Silicon or Intel, installs or updates BPB Wizard inside `~/.local/share/bpb-wizard`, and launches it.
+
+If you prefer manual installation, download the matching ZIP from the [latest release](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest), unzip it, then run `./BPB-Wizard` from Terminal.
+
+- Apple Silicon: `BPB-Wizard-darwin-arm64.zip`
+- Intel: `BPB-Wizard-darwin-amd64.zip`
+
+!!! warning
+    `BPB-Wizard` is not signed by Apple, so Gatekeeper may show a warning after a manual download.
+
+If Gatekeeper blocks it, open Terminal in the extracted folder and run:
+
+```bash title="macOS - Remove Quarantine"
+xattr -dr com.apple.quarantine BPB-Wizard
+chmod +x BPB-Wizard
+./BPB-Wizard
+```
+
+### Android (Termux) - Linux
+
+Android users who have Termux installed on their phone and Linux users can install the BPB Panel by running this command:
 
 ```bash title="Termux - Linux"
 bash <(curl -fsSL https://raw.githubusercontent.com/bia-pain-bache/BPB-Wizard/main/install.sh)

--- a/docs/fa/docs/installation/wizard.md
+++ b/docs/fa/docs/installation/wizard.md
@@ -13,13 +13,42 @@
 !!! warning
     اگه به VPN وصل هستید، قطعش کنید.
 
-### Windows و macOS
+### Windows
 
-بر اساس سیستم‌عاملتون، [فایل ZIP رو دانلود کنید](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest)، از حالت فشرده خارج کنید و برنامه رو اجرا کنید.
+بر اساس معماری سیستم‌عاملتون، [فایل ZIP مناسب رو دانلود کنید](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest)، از حالت فشرده خارج کنید و برنامه رو اجرا کنید.
+
+!!! warning
+    ویزارد فایل `worker.js` رو از GitHub دانلود می‌کنه تا شخصی‌سازی بشه و روی حساب Cloudflare شما دیپلوی بشه. چون فایل اجرایی امضای دیجیتال نداره، ممکنه Windows Defender یا آنتی‌ویروس‌های دیگه بهش هشدار بدن. اگر فایل رو از سورس رسمی گرفتید، موقتاً اجازه اجرا بدید.
+
+### macOS
+
+سریع‌ترین راه روی macOS اینه که این دستور رو داخل Terminal اجرا کنید:
+
+```bash title="macOS - Apple Silicon و Intel"
+bash <(curl -fsSL https://raw.githubusercontent.com/bia-pain-bache/BPB-Worker-Panel/main/scripts/install-macos-wizard.sh)
+```
+
+این دستور خودش تشخیص می‌ده مک شما Apple Silicon هست یا Intel، ویزارد رو داخل `~/.local/share/bpb-wizard` نصب یا به‌روزرسانی می‌کنه و بعد اجراش می‌کنه.
+
+اگه ترجیح می‌دید دستی نصب کنید، فایل ZIP مناسب رو از [آخرین Release](https://github.com/bia-pain-bache/BPB-Wizard/releases/latest) دانلود کنید، از حالت فشرده خارج کنید و بعد `./BPB-Wizard` رو داخل Terminal اجرا کنید.
+
+- Apple Silicon: `BPB-Wizard-darwin-arm64.zip`
+- Intel: `BPB-Wizard-darwin-amd64.zip`
+
+!!! warning
+    `BPB-Wizard` توسط Apple امضا نشده، برای همین ممکنه بعد از دانلود دستی، Gatekeeper بهتون هشدار نشون بده.
+
+اگر Gatekeeper جلوی اجرا رو گرفت، داخل پوشه استخراج‌شده این دستورها رو در Terminal اجرا کنید:
+
+```bash title="macOS - Remove Quarantine"
+xattr -dr com.apple.quarantine BPB-Wizard
+chmod +x BPB-Wizard
+./BPB-Wizard
+```
 
 ### Android (Termux) و Linux
 
-کاربرای اندروید که Termux رو روی گوشیشون نصب کردن، می‌تونن با کپی کردن کد زیر توی Termux پنل BPB رو نصب کنن:
+کاربرای اندروید که Termux رو روی گوشیشون نصب کردن و همین‌طور کاربرای Linux می‌تونن با اجرای دستور زیر پنل BPB رو نصب کنن:
 
 ```bash title="Termux - Linux"
 bash <(curl -fsSL https://raw.githubusercontent.com/bia-pain-bache/BPB-Wizard/main/install.sh)

--- a/scripts/install-macos-wizard.sh
+++ b/scripts/install-macos-wizard.sh
@@ -1,0 +1,93 @@
+#!/bin/bash
+
+set -euo pipefail
+
+OS=$(uname -s)
+if [ "$OS" != "Darwin" ]; then
+    echo "This script only supports macOS."
+    exit 1
+fi
+
+if ! command -v curl >/dev/null 2>&1; then
+    echo "curl is required but was not found."
+    exit 1
+fi
+
+if ! command -v unzip >/dev/null 2>&1; then
+    echo "unzip is required but was not found."
+    exit 1
+fi
+
+detect_arch() {
+    case "$(uname -m)" in
+        arm64|aarch64)
+            echo "arm64"
+            ;;
+        x86_64|amd64)
+            if [ "$(sysctl -in hw.optional.arm64 2>/dev/null || echo 0)" = "1" ]; then
+                echo "arm64"
+            else
+                echo "amd64"
+            fi
+            ;;
+        *)
+            return 1
+            ;;
+    esac
+}
+
+ARCH=$(detect_arch) || {
+    echo "Unsupported macOS architecture: $(uname -m)"
+    exit 1
+}
+
+BINARY="BPB-Wizard"
+ARCHIVE="${BINARY}-darwin-${ARCH}.zip"
+INSTALL_DIR="${BPB_WIZARD_DIR:-$HOME/.local/share/bpb-wizard}"
+BIN_PATH="${INSTALL_DIR}/${BINARY}"
+VERSION_URL="https://raw.githubusercontent.com/bia-pain-bache/BPB-Wizard/main/VERSION"
+DOWNLOAD_URL="https://github.com/bia-pain-bache/BPB-Wizard/releases/latest/download/${ARCHIVE}"
+TMP_DIR=$(mktemp -d "${TMPDIR:-/tmp}/bpb-wizard.XXXXXX")
+
+cleanup() {
+    rm -rf "$TMP_DIR"
+}
+
+trap cleanup EXIT
+
+mkdir -p "$INSTALL_DIR"
+LATEST_VERSION=$(curl -fsSL "$VERSION_URL")
+
+if [ -x "$BIN_PATH" ]; then
+    INSTALLED_VERSION=$("$BIN_PATH" --version 2>/dev/null || true)
+
+    if [ "$INSTALLED_VERSION" = "$LATEST_VERSION" ]; then
+        echo "BPB Wizard ${INSTALLED_VERSION} is already installed. Launching..."
+        exec "$BIN_PATH"
+    fi
+
+    if [ -n "$INSTALLED_VERSION" ]; then
+        echo "Updating BPB Wizard from ${INSTALLED_VERSION} to ${LATEST_VERSION}..."
+    else
+        echo "Reinstalling BPB Wizard ${LATEST_VERSION}..."
+    fi
+else
+    echo "Installing BPB Wizard ${LATEST_VERSION}..."
+fi
+
+echo "Downloading ${ARCHIVE}..."
+curl -L -# -o "${TMP_DIR}/${ARCHIVE}" "$DOWNLOAD_URL"
+
+echo "Extracting archive..."
+unzip -oq "${TMP_DIR}/${ARCHIVE}" -d "$TMP_DIR"
+
+if [ ! -f "${TMP_DIR}/${BINARY}" ]; then
+    echo "Downloaded archive does not contain ${BINARY}."
+    exit 1
+fi
+
+install -m 755 "${TMP_DIR}/${BINARY}" "$BIN_PATH"
+xattr -dr com.apple.quarantine "$INSTALL_DIR" >/dev/null 2>&1 || true
+
+echo "Installed BPB Wizard ${LATEST_VERSION} to ${BIN_PATH}"
+exec "$BIN_PATH"


### PR DESCRIPTION
## Summary
This PR adds a macOS-specific BPB Wizard bootstrap script and updates the installation docs so Mac users have a working one-command install path.

## What changed
- add `scripts/install-macos-wizard.sh` to detect Apple Silicon vs Intel Macs, download the matching BPB Wizard release, install or update it locally, clear quarantine metadata, and launch it
- update the English wizard installation guide with a macOS Terminal one-liner, manual fallback instructions, and Gatekeeper recovery steps
- mirror the same macOS guidance in the Farsi wizard installation guide
- track the new installer script in `.gitignore`

## Why
The wizard docs previously mentioned macOS, but they did not provide a dedicated install flow or a remote bootstrap command like Linux/Termux users already had. This made the macOS path harder to run remotely and more fragile around Gatekeeper warnings.

## Validation
- `bash -n scripts/install-macos-wizard.sh`
