### PR TITLE
both "NAT64Prefixes.md" path and NAT64 prefix format fixed.

### DIFF
--- a/docs/en/docs/installation/workers-manual.md
+++ b/docs/en/docs/installation/workers-manual.md
@@ -94,13 +94,14 @@ By default, the code uses multiple NAT64 prefixes randomly, assigning a new rand
 In the project’s `Settings` section, open `Variables and Secrets`, click `Add` and enter `NAT64_PREFIX` (in capital letters) in the first box. Obtain IPs from the following link, which lists IPs from various regions and ISPs:
 
 ```text
-https://github.com/bia-pain-bache/BPB-Worker-Panel/blob/main/NAT64Prefixes.md
+https://github.com/bia-pain-bache/BPB-Worker-Panel/blob/main/docs/NAT64Prefixes.md
 ```
 
 !!! info
-    To use multiple IPs, fill them comma-separated.
+    To use multiple IPs, enter each prefix on a new line using [].
     ```title="Example"
-    [2602:fc59:b0:64::], [2602:fc59:11:64::]
+    [2602:fc59:b0:64::]
+    [2602:fc59:11:64::]
     ```
 
 Enter the IPs in the `Value` field and click `Deploy`.


### PR DESCRIPTION
This PR fixes two documentation issues I faced in the NAT64 section:

1. corrects the NAT64Prefixes.md path
2. updates the prefix format instructions to match the actual validation rule
<img width="763" height="275" alt="Screenshot 2026-06-09 at 5 32 09 PM" src="https://github.com/user-attachments/assets/247ea246-df43-4fc9-8cd5-2af1338ea79f" />