### PR TITLE
fix: adjust credential charset for better copy-paste compatibility

### DIFF
--- a/src/assets/secrets/script.js
+++ b/src/assets/secrets/script.js
@@ -8,7 +8,7 @@ function generateUUID() {
 
 function generateStrongPassword() {
     const charset =
-        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@#$%^&*()_+[]{}|;:',.<>?";
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@%^&*()_+|;:,.<>?";
     let password = '';
     const randomValues = new Uint8Array(16);
     crypto.getRandomValues(randomValues);
@@ -20,7 +20,7 @@ function generateStrongPassword() {
 }
 
 function generateSubURIPath() {
-    const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789!@$&*_-+;:,.";
+    const charset = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-~";
     let uriPath = '';
     const randomValues = new Uint8Array(16);
     crypto.getRandomValues(randomValues);


### PR DESCRIPTION
### Description
This PR fixes a copy-paste compatibility issue when adding credentials to the Cloudflare **Variables and secrets** panel. 

### The Problem
When a user copies the generated credentials to their clipboard and attempts to paste the entire block (`UUID=${uuid}\nTR_PASS=${password}\nSUB_PATH=${uriPath}`) directly into Cloudflare, specific characters within the `TR_PASS` value cause the string to truncate. 

Specifically, the characters `#`, `$`, `[`, `]`, `{`, `}`, and `'` trigger syntax flags or comment rules in Cloudflare's environment parser. This causes the platform to drop the rest of the password, resulting in an incomplete or broken value being saved.

### Changes
- **TR_PASS:** Updated the generation pool to exclude characters that break the Cloudflare parser (`#`, `$`, brackets, and quotes) while maintaining strong entropy.
- **SUB_PATH:** Refactored the generator to produce highly safe, URL-friendly strings to ensure reliable routing without parsing glitches.
- **UX Improvement:** Users can now copy and paste the generated credentials directly into Cloudflare variables seamlessly without any character loss.