### PR TITLE
Added i18n support for Chinese and English UI.

### DIFF
--- a/scripts/build.js
+++ b/scripts/build.js
@@ -30,6 +30,8 @@ const version = pkg.version;
 
 async function processHtmlPages() {
     const indexFiles = globSync('**/index.html', { cwd: ASSET_PATH });
+    const i18nCode = readFileSync(join(ASSET_PATH, 'i18n.js'), 'utf8');
+    const i18nMinified = (await jsMinify(i18nCode)).code;
     const result = {};
 
     for (const relativeIndexPath of indexFiles) {
@@ -45,6 +47,7 @@ async function processHtmlPages() {
             const finalScriptCode = await jsMinify(scriptCode);
             finalHtml = finalHtml
                 .replaceAll('__STYLE__', `<style>${styleCode}</style>`)
+                .replaceAll('__I18N__', i18nMinified)
                 .replaceAll('__SCRIPT__', finalScriptCode.code);
         }
 

--- a/src/assets/error/index.html
+++ b/src/assets/error/index.html
@@ -61,7 +61,7 @@
             </span>
         </h1>
         <div>
-            <h2>❌ Something went wrong!</h2>
+            <h2 id="err-title">❌ Something went wrong!</h2>
             <p>
                 <b>__ERROR_MESSAGE__</b>
             </p>
@@ -69,6 +69,13 @@
     </div>
     <script>
         localStorage.getItem('darkMode') === 'enabled' && document.body.classList.add('dark-mode');
+        (() => {
+            const lang = (localStorage.getItem('lang') === 'zh' || localStorage.getItem('lang') === 'en')
+                ? localStorage.getItem('lang')
+                : (navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en');
+            document.documentElement.lang = lang;
+            if (lang === 'zh') document.getElementById('err-title').textContent = '❌ 出错了!';
+        })();
     </script>
 </body>
 

--- a/src/assets/i18n.js
+++ b/src/assets/i18n.js
@@ -1,0 +1,524 @@
+(() => {
+    const D = {
+        en: {
+            common: {
+                help: 'Help',
+                enabled: 'Enabled',
+                disabled: 'Disabled',
+                loading: 'Loading...',
+                apply: 'Apply',
+                update: 'Update',
+                login: 'Login',
+                logout: 'Log out',
+                copyAll: 'Copy all',
+                lang: 'EN'
+            },
+            panel: {
+                settingsTitle: 'Settings',
+                common: {
+                    title: 'Common',
+                    localDNS: '🏚️ Local DNS',
+                    antiSanctionDNS: '🌏 Anti Sanction DNS',
+                    fakeDNS: '🧢 Fake DNS',
+                    ipv6: '🔛 IPv6',
+                    allowLAN: '⛔ Allow connections from LAN',
+                    logLevel: '🎚️ Log Level',
+                    logLevelNone: 'Disabled',
+                    logLevelWarning: 'Warning',
+                    logLevelError: 'Error',
+                    logLevelInfo: 'Info',
+                    logLevelDebug: 'Debug'
+                },
+                vlTr: {
+                    title: 'VLESS - Trojan',
+                    remoteDNS: '🌏 Remote DNS',
+                    upstreamProxy: '🚪 Upstream TCP Proxy',
+                    chainProxy: '✈️ Chain Proxy',
+                    cleanIPs: '✨ Clean IPs / Domains',
+                    scannerTitle: 'Scanner',
+                    protocols: '⚙️ Protocols',
+                    tlsPorts: '🔒 TLS Ports',
+                    nonTlsPorts: '🔓 non-TLS Ports',
+                    fingerprint: '👆 Fingerprint',
+                    bestInterval: '🔄 Best Interval',
+                    tcpFastOpen: '⏩ TCP Fast Open',
+                    echTitle: 'ECH',
+                    enableECH: '🎭 ECH',
+                    echServerName: '🧢 ECH Server Name',
+                    proxyIPTitle: 'Proxy IP',
+                    mode: '🎚️ Mode',
+                    proxyIPs: '📍 Proxy IPs / Domains',
+                    proxyIPsLink: 'Proxy IPs',
+                    nat64Prefixes: '📍 NAT64 Prefixes',
+                    nat64PrefixesLink: 'NAT64 prefixes',
+                    customCdnTitle: 'Custom CDN',
+                    addresses: '💀 Addresses',
+                    host: '💀 Host',
+                    sni: '💀 SNI'
+                },
+                fragment: {
+                    title: 'Xray Fragment',
+                    mode: '🎚️ Mode',
+                    modeCustom: 'Custom',
+                    modeLow: 'Low',
+                    modeMedium: 'Medium',
+                    modeHigh: 'High',
+                    modeSevere: 'Severe',
+                    length: '📐 Length',
+                    interval: '🕞 Interval',
+                    maxSplit: '⛓️ Max Split',
+                    packets: '📦 Packets'
+                },
+                externalRaw: {
+                    title: 'External Raw Configs',
+                    subscriptions: '🔗 Subscriptions',
+                    singleConfigs: '➕ Single Configs'
+                },
+                warpGeneral: {
+                    title: 'Warp General',
+                    remoteDNS: '🌏 remote DNS',
+                    endpoints: '✨ Endpoints',
+                    bestInterval: '🔄 Best Interval',
+                    warpAccounts: '♻️ Warp Accounts'
+                },
+                warpPro: {
+                    title: 'Warp PRO',
+                    mahsaNoise: 'MahsaNG Noise',
+                    clashAmnezia: 'Clash - Amnezia Noise',
+                    v2rayNoise: 'v2rayNG - v2rayN Noise',
+                    knockerMode: '😵‍💫 Mode',
+                    knockerModeTip: "Fill in 'none', 'quic', 'random', or any HEX string like 'ee0000000108aaaa'",
+                    count: '🎚️ Count',
+                    size: '📏 Size',
+                    delay: '🕞 Delay',
+                    noiseLabel: 'Noise {n}',
+                    noiseMode: '😵‍💫 Mode',
+                    packet: '📦 Packet'
+                },
+                routing: {
+                    title: 'Routing Rules',
+                    preset: 'Preset Rules',
+                    bypassRules: '🟩 Bypass rules',
+                    blockRules: '🟥 Block rules',
+                    custom: 'Custom Rules',
+                    customBypass: '🟩 Bypass IPs / Domains',
+                    customBlock: '🟥 Block IPs / Domains',
+                    sanction: 'Sanction Rules',
+                    sanctionBypass: '🟩 Bypass rules',
+                    sanctionBypassDomains: '🟩 Bypass Domains',
+                    iran: 'Iran',
+                    china: 'China',
+                    russia: 'Russia',
+                    ads: 'Ads.',
+                    porn: 'Porn',
+                    quic: 'QUIC',
+                    malware: 'Malware',
+                    phishing: 'Phishing',
+                    cryptominers: 'Cryptominers'
+                },
+                apply: {
+                    reset: 'Reset panel settings to default',
+                    export: 'Export panel settings',
+                    import: 'Import panel settings'
+                },
+                sub: {
+                    title: 'Subscriptions',
+                    normal: 'Normal',
+                    fragment: 'Fragment',
+                    raw: 'Raw (without settings)',
+                    warp: 'Warp',
+                    warpPro: 'Warp PRO',
+                    qrTitle: 'Display QR code',
+                    copyTitle: 'Copy subscription URL',
+                    dlTitle: 'Download config',
+                    dlZipTitle: 'Download configs zip',
+                    normalSub: 'Normal Subscription',
+                    fragmentSub: 'Fragment Subscription',
+                    rawSub: 'Raw Subscription',
+                    warpSub: 'Warp Subscription',
+                    warpProSub: 'Warp Pro Subscription'
+                },
+                doh: 'DNS over HTTPS',
+                myIp: {
+                    title: 'My IP',
+                    info: 'Information',
+                    cf: 'Cloudflare targets',
+                    other: 'Other targets',
+                    ip: 'IP',
+                    country: 'Country',
+                    city: 'City',
+                    isp: 'ISP'
+                },
+                pwd: {
+                    title: 'Change Password',
+                    newPwd: 'New Password',
+                    confirmPwd: 'Confirm Password',
+                    submit: 'Change Password',
+                    notMatch: 'Passwords do not match',
+                    weak: '⚠️ Password must contain at least one capital letter, one number, and be at least 8 characters long.',
+                    success: '✅ Password changed successfully! 👍'
+                },
+                footer: {
+                    changePwd: 'Change Password',
+                    logoutTitle: 'Log out'
+                },
+                alert: {
+                    copied: '✅ Copied to clipboard:\n\n{text}',
+                    warpConfirm: '⚠️ Are you sure?',
+                    warpFail: '⚠️ An error occured, Please try again!\n⛔ {message}',
+                    warpSuccess: '✅ Warp configs updated successfully!',
+                    needOneProtocol: '⛔ At least one Protocol should be selected!',
+                    needOneTlsPort: '⛔ At least one TLS port should be selected!',
+                    riskyRules: "⛔ v2ray users should set Geo Assets to Chocolate4U and download assets, otherwise configs won't connect.\n\n❓ Proceed?",
+                    resetConfirm: '⚠️ This will reset all panel settings.\n\n❓ Are you sure?',
+                    resetSuccess: '✅ Panel settings reset to default successfully!\n💡 Please update your subscriptions.',
+                    sessionExpired: '⚠️ Session expired! Please login again.',
+                    settingsApplied: '✅ Settings applied successfully!\n💡 Please update your subscriptions.',
+                    loading: '⌛ Loading...',
+                    invalidDnsUrl: '⛔ Invalid DNS, Please enter a URL.',
+                    invalidDnsProto: '⛔ Please enter TCP, DoH or DoT servers.',
+                    cfDnsForbidden: '⛔ Cloudflare DNS is not allowed for workers.\n💡 Please use other public DNS servers like Google, Adguard...',
+                    invalidHosts: '⛔ Invalid IPs or Domains.\n⚠️ {host}',
+                    invalidWarpDns: '⛔ Invalid Warp DNS.\n💡 Please fill in an IPv4 address (UDP DNS).\n\n⚠️ {dns}',
+                    invalidLocalDns: '⛔ Invalid local DNS.\n💡 Please fill in an IPv4 address or "localhost".\n\n⚠️ {dns}',
+                    invalidIpDomainList: '⛔ Invalid IPs, Domains or IP ranges.\n💡 Please enter each value in a new line.\n\n{list}',
+                    invalidDomainList: '⛔ Invalid Domains.\n💡 Please enter each value in a new line.\n\n{list}',
+                    invalidIpDomainListShort: '⛔ Invalid IPs or Domains.\n💡 Please enter each value in a new line.\n\n{list}',
+                    invalidProxyIPs: '⛔ Invalid proxy IPs.\n💡 Please enter each value in a new line.\n\n{list}',
+                    invalidNat64: '⛔ Invalid NAT64 prefix.\n💡 Please enter each prefix in a new line using [].\n\n{list}',
+                    invalidEndpoint: '⛔ Invalid endpoint.\n\n{list}',
+                    minMax: '⛔ {label}: Minimum cannot be bigger than Maximum!',
+                    invalidConfig: '⛔ Invalid Config!\n💡 Standard formats are:\n\n + (socks or socks5 or http)://user:pass@server:port\n + (socks or socks5 or http)://base64@server:port\n + vless://uuid@server:port...\n + vmess://base64\n + trojan://password@server:port...\n + ss://base64@server:port...',
+                    configNoUser: '⛔ Invalid Config!\n💡 Config URL should contain UUID or Password.',
+                    configBadSec: '⛔ Invalid Config!\n💡 VLESS, VMess or Trojan security can be TLS, Reality or None.',
+                    configBadType: '⛔ Invalid Config!\n💡 VLESS, VMess or Trojan transmission can be tcp, ws, grpc or httpupgrade.',
+                    cdnAllOrNone: '⛔ All "Custom" fields should be filled or deleted together!',
+                    invalidKnockerNoise: '⛔ Invalid noise  mode.\n💡 Please use "none", "quic", "random" or a valid hex value.',
+                    noiseDelayMinMax: '⛔ The minimum noise delay should be smaller or equal to maximum!',
+                    base64Invalid: '⛔ The Base64 noise packet is not a valid base64 value!',
+                    randInvalid: '⛔ The Random noise packet should be a range like 0-10 or 10-30!',
+                    randMinMax: '⛔ The minimum Random noise packet should be smaller or equal to maximum!',
+                    hexInvalid: '⛔ The Hex noise packet is not a valid hex value!\n💡 It should have even length and consisted of 0-9, a-f and A-F.',
+                    arrayInvalid: '⛔ The values should be comma separated numbers between 0-255',
+                    echDomain: '⛔ The ECH Server Name should be a domain!',
+                    invalidUpstream: '⛔ Invalid Upstream proxy!\n💡 It can be either IP:Port or Domain:Port',
+                    noiseDeleteAll: '⛔ You cannot delete all noises!',
+                    noiseDeleteConfirm: '⚠️ This will delete the noise.\n\n❓ Are you sure?'
+                },
+                fragLabel: 'Fragment Length',
+                fragInterval: 'Fragment Interval',
+                fragMaxSplit: 'Fragment Max Split',
+                noiseCount: 'Noise Count',
+                noiseSize: 'Noise Size',
+                noiseDelay: 'Noise Delay',
+                amneziaSize: 'Amnezia Noise Size'
+            },
+            login: {
+                title: 'User Login',
+                password: 'Password',
+                wrong: '⚠️ Wrong Password!'
+            },
+            secrets: {
+                title: 'Secrets generator',
+                uuid: 'Random UUID',
+                trPass: 'Random Trojan Password',
+                subPath: 'Random Subscription URI path',
+                copied: '✅ Copied to clipboard!'
+            },
+            proxyIp: {
+                num: '#',
+                proxyIp: 'Proxy IP',
+                country: 'Country',
+                city: 'City',
+                isp: 'ISP',
+                loading: 'Loading...',
+                failed: 'Failed to get Proxy IPs',
+                error: 'Error: {msg}'
+            },
+            error: {
+                title: '❌ Something went wrong!'
+            }
+        },
+        zh: {
+            common: {
+                help: '帮助',
+                enabled: '启用',
+                disabled: '禁用',
+                loading: '加载中...',
+                apply: '应用',
+                update: '更新',
+                login: '登录',
+                logout: '退出',
+                copyAll: '复制全部',
+                lang: '中'
+            },
+            panel: {
+                settingsTitle: '设置',
+                common: {
+                    title: '通用',
+                    localDNS: '🏚️ 本地 DNS',
+                    antiSanctionDNS: '🌏 反制裁 DNS',
+                    fakeDNS: '🧢 Fake DNS',
+                    ipv6: '🔛 IPv6',
+                    allowLAN: '⛔ 允许局域网连接',
+                    logLevel: '🎚️ 日志级别',
+                    logLevelNone: '关闭',
+                    logLevelWarning: '警告',
+                    logLevelError: '错误',
+                    logLevelInfo: '信息',
+                    logLevelDebug: '调试'
+                },
+                vlTr: {
+                    title: 'VLESS - Trojan',
+                    remoteDNS: '🌏 远程 DNS',
+                    upstreamProxy: '🚪 上游 TCP 代理',
+                    chainProxy: '✈️ 链式代理',
+                    cleanIPs: '✨ 优选 IP / 域名',
+                    scannerTitle: '扫描器',
+                    protocols: '⚙️ 协议',
+                    tlsPorts: '🔒 TLS 端口',
+                    nonTlsPorts: '🔓 非 TLS 端口',
+                    fingerprint: '👆 指纹',
+                    bestInterval: '🔄 测速间隔',
+                    tcpFastOpen: '⏩ TCP 快速打开',
+                    echTitle: 'ECH',
+                    enableECH: '🎭 ECH',
+                    echServerName: '🧢 ECH 服务器名称',
+                    proxyIPTitle: '代理 IP',
+                    mode: '🎚️ 模式',
+                    proxyIPs: '📍 代理 IP / 域名',
+                    proxyIPsLink: '代理 IP 列表',
+                    nat64Prefixes: '📍 NAT64 前缀',
+                    nat64PrefixesLink: 'NAT64 前缀说明',
+                    customCdnTitle: '自定义 CDN',
+                    addresses: '💀 地址',
+                    host: '💀 主机',
+                    sni: '💀 SNI'
+                },
+                fragment: {
+                    title: 'Xray 分片',
+                    mode: '🎚️ 模式',
+                    modeCustom: '自定义',
+                    modeLow: '低',
+                    modeMedium: '中',
+                    modeHigh: '高',
+                    modeSevere: '极致',
+                    length: '📐 长度',
+                    interval: '🕞 间隔',
+                    maxSplit: '⛓️ 最大分片',
+                    packets: '📦 数据包'
+                },
+                externalRaw: {
+                    title: '外部原始配置',
+                    subscriptions: '🔗 订阅',
+                    singleConfigs: '➕ 单条配置'
+                },
+                warpGeneral: {
+                    title: 'Warp 通用',
+                    remoteDNS: '🌏 远程 DNS',
+                    endpoints: '✨ 端点',
+                    bestInterval: '🔄 测速间隔',
+                    warpAccounts: '♻️ Warp 账户'
+                },
+                warpPro: {
+                    title: 'Warp PRO',
+                    mahsaNoise: 'MahsaNG 噪声',
+                    clashAmnezia: 'Clash - Amnezia 噪声',
+                    v2rayNoise: 'v2rayNG - v2rayN 噪声',
+                    knockerMode: '😵‍💫 模式',
+                    knockerModeTip: "填入 'none'、'quic'、'random' 或十六进制串(如 'ee0000000108aaaa')",
+                    count: '🎚️ 数量',
+                    size: '📏 大小',
+                    delay: '🕞 延迟',
+                    noiseLabel: '噪声 {n}',
+                    noiseMode: '😵‍💫 模式',
+                    packet: '📦 数据包'
+                },
+                routing: {
+                    title: '路由规则',
+                    preset: '预设规则',
+                    bypassRules: '🟩 绕过规则',
+                    blockRules: '🟥 阻止规则',
+                    custom: '自定义规则',
+                    customBypass: '🟩 绕过 IP / 域名',
+                    customBlock: '🟥 阻止 IP / 域名',
+                    sanction: '制裁规则',
+                    sanctionBypass: '🟩 绕过规则',
+                    sanctionBypassDomains: '🟩 绕过域名',
+                    iran: '伊朗',
+                    china: '中国',
+                    russia: '俄罗斯',
+                    ads: '广告',
+                    porn: '成人',
+                    quic: 'QUIC',
+                    malware: '恶意软件',
+                    phishing: '钓鱼',
+                    cryptominers: '挖矿'
+                },
+                apply: {
+                    reset: '重置面板设置为默认',
+                    export: '导出面板设置',
+                    import: '导入面板设置'
+                },
+                sub: {
+                    title: '订阅',
+                    normal: '普通',
+                    fragment: '分片',
+                    raw: '原始(无设置)',
+                    warp: 'Warp',
+                    warpPro: 'Warp PRO',
+                    qrTitle: '显示二维码',
+                    copyTitle: '复制订阅链接',
+                    dlTitle: '下载配置',
+                    dlZipTitle: '下载配置压缩包',
+                    normalSub: '普通订阅',
+                    fragmentSub: '分片订阅',
+                    rawSub: '原始订阅',
+                    warpSub: 'Warp 订阅',
+                    warpProSub: 'Warp Pro 订阅'
+                },
+                doh: 'DNS over HTTPS',
+                myIp: {
+                    title: '我的 IP',
+                    info: '信息',
+                    cf: 'Cloudflare 目标',
+                    other: '其他目标',
+                    ip: 'IP',
+                    country: '国家',
+                    city: '城市',
+                    isp: '运营商'
+                },
+                pwd: {
+                    title: '修改密码',
+                    newPwd: '新密码',
+                    confirmPwd: '确认密码',
+                    submit: '修改密码',
+                    notMatch: '两次输入的密码不一致',
+                    weak: '⚠️ 密码至少 8 位,且必须包含至少一个大写字母和一个数字。',
+                    success: '✅ 密码修改成功! 👍'
+                },
+                footer: {
+                    changePwd: '修改密码',
+                    logoutTitle: '退出登录'
+                },
+                alert: {
+                    copied: '✅ 已复制到剪贴板:\n\n{text}',
+                    warpConfirm: '⚠️ 确定要继续吗?',
+                    warpFail: '⚠️ 发生错误,请重试!\n⛔ {message}',
+                    warpSuccess: '✅ Warp 配置已成功更新!',
+                    needOneProtocol: '⛔ 至少要选择一个协议!',
+                    needOneTlsPort: '⛔ 至少要选择一个 TLS 端口!',
+                    riskyRules: '⛔ v2ray 用户需将 Geo 资源设置为 Chocolate4U 并下载资源,否则配置无法连接。\n\n❓ 是否继续?',
+                    resetConfirm: '⚠️ 此操作将重置所有面板设置。\n\n❓ 确定要继续吗?',
+                    resetSuccess: '✅ 面板设置已成功重置为默认!\n💡 请更新你的订阅。',
+                    sessionExpired: '⚠️ 会话已过期!请重新登录。',
+                    settingsApplied: '✅ 设置已成功应用!\n💡 请更新你的订阅。',
+                    loading: '⌛ 加载中...',
+                    invalidDnsUrl: '⛔ DNS 无效,请输入一个 URL。',
+                    invalidDnsProto: '⛔ 请输入 TCP、DoH 或 DoT 服务器。',
+                    cfDnsForbidden: '⛔ Workers 不允许使用 Cloudflare DNS。\n💡 请使用其他公共 DNS,如 Google、Adguard…',
+                    invalidHosts: '⛔ IP 或域名无效。\n⚠️ {host}',
+                    invalidWarpDns: '⛔ Warp DNS 无效。\n💡 请填入 IPv4 地址(UDP DNS)。\n\n⚠️ {dns}',
+                    invalidLocalDns: '⛔ 本地 DNS 无效。\n💡 请填入 IPv4 地址或 "localhost"。\n\n⚠️ {dns}',
+                    invalidIpDomainList: '⛔ IP、域名或 IP 段无效。\n💡 请每行输入一个值。\n\n{list}',
+                    invalidDomainList: '⛔ 域名无效。\n💡 请每行输入一个值。\n\n{list}',
+                    invalidIpDomainListShort: '⛔ IP 或域名无效。\n💡 请每行输入一个值。\n\n{list}',
+                    invalidProxyIPs: '⛔ 代理 IP 无效。\n💡 请每行输入一个值。\n\n{list}',
+                    invalidNat64: '⛔ NAT64 前缀无效。\n💡 请每行输入一个,使用 [] 包裹。\n\n{list}',
+                    invalidEndpoint: '⛔ 端点无效。\n\n{list}',
+                    minMax: '⛔ {label}:最小值不能大于最大值!',
+                    invalidConfig: '⛔ 配置无效!\n💡 标准格式如下:\n\n + (socks 或 socks5 或 http)://user:pass@server:port\n + (socks 或 socks5 或 http)://base64@server:port\n + vless://uuid@server:port...\n + vmess://base64\n + trojan://password@server:port...\n + ss://base64@server:port...',
+                    configNoUser: '⛔ 配置无效!\n💡 配置 URL 必须包含 UUID 或密码。',
+                    configBadSec: '⛔ 配置无效!\n💡 VLESS、VMess 或 Trojan 的安全方式只能是 TLS、Reality 或 None。',
+                    configBadType: '⛔ 配置无效!\n💡 VLESS、VMess 或 Trojan 的传输方式只能是 tcp、ws、grpc 或 httpupgrade。',
+                    cdnAllOrNone: '⛔ 所有 "自定义" 字段必须全部填写或一起删除!',
+                    invalidKnockerNoise: '⛔ 噪声模式无效。\n💡 请使用 "none"、"quic"、"random" 或有效的十六进制值。',
+                    noiseDelayMinMax: '⛔ 最小噪声延迟必须小于或等于最大值!',
+                    base64Invalid: '⛔ Base64 噪声包不是有效的 base64 值!',
+                    randInvalid: '⛔ Random 噪声包必须是 0-10 或 10-30 这样的区间!',
+                    randMinMax: '⛔ Random 噪声包的最小值必须小于或等于最大值!',
+                    hexInvalid: '⛔ Hex 噪声包不是有效的十六进制!\n💡 长度必须为偶数,且仅包含 0-9、a-f、A-F。',
+                    arrayInvalid: '⛔ 值必须是 0-255 之间的英文逗号分隔数字',
+                    echDomain: '⛔ ECH 服务器名称必须是一个域名!',
+                    invalidUpstream: '⛔ 上游代理无效!\n💡 必须为 IP:端口 或 域名:端口',
+                    noiseDeleteAll: '⛔ 不能删除全部噪声!',
+                    noiseDeleteConfirm: '⚠️ 此操作将删除该噪声。\n\n❓ 确定要继续吗?'
+                },
+                fragLabel: '分片长度',
+                fragInterval: '分片间隔',
+                fragMaxSplit: '分片最大数',
+                noiseCount: '噪声数量',
+                noiseSize: '噪声大小',
+                noiseDelay: '噪声延迟',
+                amneziaSize: 'Amnezia 噪声大小'
+            },
+            login: {
+                title: '用户登录',
+                password: '密码',
+                wrong: '⚠️ 密码错误!'
+            },
+            secrets: {
+                title: '密钥生成器',
+                uuid: '随机 UUID',
+                trPass: '随机 Trojan 密码',
+                subPath: '随机订阅 URI 路径',
+                copied: '✅ 已复制到剪贴板!'
+            },
+            proxyIp: {
+                num: '#',
+                proxyIp: '代理 IP',
+                country: '国家',
+                city: '城市',
+                isp: '运营商',
+                loading: '加载中...',
+                failed: '获取代理 IP 失败',
+                error: '错误:{msg}'
+            },
+            error: {
+                title: '❌ 出错了!'
+            }
+        }
+    };
+
+    const getLang = () => {
+        const stored = localStorage.getItem('lang');
+        if (stored === 'zh' || stored === 'en') return stored;
+        return navigator.language.toLowerCase().startsWith('zh') ? 'zh' : 'en';
+    };
+
+    const lookup = key => key.split('.').reduce((o, k) => o[k], D[getLang()]);
+
+    window.t = (key, params) => {
+        let s = lookup(key);
+        if (params) for (const k in params) s = s.replaceAll('{' + k + '}', params[k]);
+        return s;
+    };
+
+    window.applyI18n = () => {
+        document.documentElement.lang = getLang();
+        document.querySelectorAll('[data-i18n]').forEach(el => el.textContent = t(el.dataset.i18n));
+        document.querySelectorAll('[data-i18n-title]').forEach(el => el.title = t(el.dataset.i18nTitle));
+        document.querySelectorAll('[data-i18n-html]').forEach(el => el.innerHTML = t(el.dataset.i18nHtml));
+    };
+
+    window.setLang = lang => {
+        localStorage.setItem('lang', lang);
+        applyI18n();
+        const btn = document.getElementById('langToggle');
+        if (btn) btn.textContent = lang === 'zh' ? 'EN' : '中';
+    };
+
+    window.toggleLang = () => setLang(getLang() === 'zh' ? 'en' : 'zh');
+
+    const init = () => {
+        applyI18n();
+        const btn = document.getElementById('langToggle');
+        if (btn) btn.textContent = getLang() === 'zh' ? 'EN' : '中';
+    };
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/src/assets/login/index.html
+++ b/src/assets/login/index.html
@@ -21,10 +21,10 @@
             </span>
         </h1>
         <div class="form-container">
-            <h2>User Login</h2>
+            <h2 data-i18n="login.title"></h2>
             <form id="loginForm" class="login-form">
                 <div class="form-control">
-                    <label for="password">Password</label>
+                    <label for="password" data-i18n="login.password"></label>
                     <div class="password-wrapper">
                         <input type="password" id="password" name="password" required>
                         <span id="togglePassword" class="material-symbols-rounded toggle-password">
@@ -34,7 +34,7 @@
                 </div>
                 <div id="passwordError" class="hint"></div>
                 <button type="submit" class="button">
-                    Login
+                    <span data-i18n="common.login"></span>
                     <span class="material-symbols-rounded">
                         login
                     </span>
@@ -42,6 +42,8 @@
             </form>
         </div>
     </div>
+    <button id="langToggle" class="lang-toggle-fixed" onclick="toggleLang()">中</button>
+    <script>__I18N__</script>
     <script>__SCRIPT__</script>
 </body>
 

--- a/src/assets/login/script.js
+++ b/src/assets/login/script.js
@@ -15,7 +15,7 @@ document.getElementById('loginForm').addEventListener('submit', async (event) =>
         const { success, status, message } = await response.json();
         if (!success) {
             const passwordError = document.getElementById("passwordError");
-            passwordError.textContent = '⚠️ Wrong Password!';
+            passwordError.textContent = t('login.wrong');
             throw new Error(`Login failed with status ${status}: ${message}`);
         }
 

--- a/src/assets/login/style.css
+++ b/src/assets/login/style.css
@@ -181,3 +181,25 @@ button {
         width: 30%;
     }
 }
+
+.lang-toggle-fixed {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: var(--color);
+    color: var(--background-color);
+    border: none;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transition: transform 0.3s;
+    z-index: 1000;
+}
+
+.lang-toggle-fixed:hover {
+    transform: scale(1.1);
+}

--- a/src/assets/panel/index.html
+++ b/src/assets/panel/index.html
@@ -20,66 +20,66 @@
         </span>
     </h1>
     <div class="form-container container">
-        <h2><span class="material-symbols-rounded">settings</span> Settings</h2>
+        <h2><span class="material-symbols-rounded">settings</span> <span data-i18n="panel.settingsTitle"></span></h2>
         <form id="configForm" class="configForm" onsubmit="updateSettings(event)">
             <details>
                 <summary>
-                    <h3>Common
+                    <h3><span data-i18n="panel.common.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/common/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="form-control">
-                        <label for="localDNS">🏚️ Local DNS</label>
+                        <label for="localDNS" data-i18n="panel.common.localDNS"></label>
                         <div>
                             <input type="text" id="localDNS" name="localDNS" required>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="antiSanctionDNS">🌏 Anti Sanction DNS</label>
+                        <label for="antiSanctionDNS" data-i18n="panel.common.antiSanctionDNS"></label>
                         <div>
                             <input type="text" id="antiSanctionDNS" name="antiSanctionDNS" required>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fakeDNS">🧢 Fake DNS</label>
+                        <label for="fakeDNS" data-i18n="panel.common.fakeDNS"></label>
                         <div>
                             <select id="fakeDNS" name="fakeDNS">
-                                <option value="true">Enabled</option>
-                                <option value="false">Disabled</option>
+                                <option value="true" data-i18n="common.enabled"></option>
+                                <option value="false" data-i18n="common.disabled"></option>
                             </select>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="enableIPv6">🔛 IPv6</label>
+                        <label for="enableIPv6" data-i18n="panel.common.ipv6"></label>
                         <div>
                             <select id="enableIPv6" name="enableIPv6">
-                                <option value="true">Enabled</option>
-                                <option value="false">Disabled</option>
+                                <option value="true" data-i18n="common.enabled"></option>
+                                <option value="false" data-i18n="common.disabled"></option>
                             </select>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="allowLANConnection">⛔ Allow connections from LAN</label>
+                        <label for="allowLANConnection" data-i18n="panel.common.allowLAN"></label>
                         <div>
                             <select id="allowLANConnection" name="allowLANConnection">
-                                <option value="true">Enabled</option>
-                                <option value="false">Disabled</option>
+                                <option value="true" data-i18n="common.enabled"></option>
+                                <option value="false" data-i18n="common.disabled"></option>
                             </select>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="logLevel">🎚️ Log Level</label>
+                        <label for="logLevel" data-i18n="panel.common.logLevel"></label>
                         <div>
                             <select id="logLevel" name="logLevel">
-                                <option value="none">Disabled</option>
-                                <option value="warning">Warning</option>
-                                <option value="error">Error</option>
-                                <option value="info">Info</option>
-                                <option value="debug">Debug</option>
+                                <option value="none" data-i18n="panel.common.logLevelNone"></option>
+                                <option value="warning" data-i18n="panel.common.logLevelWarning"></option>
+                                <option value="error" data-i18n="panel.common.logLevelError"></option>
+                                <option value="info" data-i18n="panel.common.logLevelInfo"></option>
+                                <option value="debug" data-i18n="panel.common.logLevelDebug"></option>
                             </select>
                         </div>
                     </div>
@@ -87,37 +87,37 @@
             </details>
             <details class="details">
                 <summary>
-                    <h3>VLESS - Trojan
+                    <h3><span data-i18n="panel.vlTr.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/vless-trojan/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="form-control">
-                        <label for="remoteDNS">🌏 Remote DNS</label>
+                        <label for="remoteDNS" data-i18n="panel.vlTr.remoteDNS"></label>
                         <div>
                             <input type="text" id="remoteDNS" name="remoteDNS" required>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="upstreamProxy">🚪 Upstream TCP Proxy</label>
+                        <label for="upstreamProxy" data-i18n="panel.vlTr.upstreamProxy"></label>
                         <div>
                             <input type="text" id="upstreamProxy" name="upstreamProxy">
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="outProxy">✈️ Chain Proxy</label>
+                        <label for="outProxy" data-i18n="panel.vlTr.chainProxy"></label>
                         <div>
                             <input type="text" id="outProxy" name="outProxy">
                         </div>
                     </div>
                     <div class="form-control">
                         <label for="cleanIPs">
-                            ✨ Clean IPs / Domains
+                            <span data-i18n="panel.vlTr.cleanIPs"></span>
                             <a class="scanner" href="https://github.com/bia-pain-bache/Cloudflare-Clean-IP-Scanner"
-                                title="Scanner" target="_blank" rel="noopener noreferrer">
+                                data-i18n-title="panel.vlTr.scannerTitle" target="_blank" rel="noopener noreferrer">
                                 <span class="material-symbols-rounded">open_in_new</span>
                             </a>
                         </label>
@@ -126,7 +126,7 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="VLConfigs">⚙️ Protocols</label>
+                        <label for="VLConfigs" data-i18n="panel.vlTr.protocols"></label>
                         <div>
                             <div class="protocols inner-container">
                                 <div class="proto">
@@ -143,19 +143,19 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="tls-ports">🔒 TLS Ports</label>
+                        <label for="tls-ports" data-i18n="panel.vlTr.tlsPorts"></label>
                         <div>
                             <div id="tls-ports" class="rules inner-container"></div>
                         </div>
                     </div>
                     <div id="none-tls" class="form-control" style="display: none;">
-                        <label for="non-tls-ports">🔓 non-TLS Ports</label>
+                        <label for="non-tls-ports" data-i18n="panel.vlTr.nonTlsPorts"></label>
                         <div>
                             <div id="non-tls-ports" class="rules inner-container"></div>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fingerprint">👆 Fingerprint</label>
+                        <label for="fingerprint" data-i18n="panel.vlTr.fingerprint"></label>
                         <div>
                             <select id="fingerprint" name="fingerprint">
                                 <option value="chrome">chrome</option>
@@ -172,34 +172,34 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="bestVLTRInterval">🔄 Best Interval</label>
+                        <label for="bestVLTRInterval" data-i18n="panel.vlTr.bestInterval"></label>
                         <div>
                             <input type="number" id="bestVLTRInterval" name="bestVLTRInterval" min="10" max="90">
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="enableTFO">⏩ TCP Fast Open</label>
+                        <label for="enableTFO" data-i18n="panel.vlTr.tcpFastOpen"></label>
                         <div>
                             <select id="enableTFO" name="enableTFO">
-                                <option value="true">Enabled</option>
-                                <option value="false">Disabled</option>
+                                <option value="true" data-i18n="common.enabled"></option>
+                                <option value="false" data-i18n="common.disabled"></option>
                             </select>
                         </div>
                     </div>
                     <div class="container">
                         <div class="section">
-                            <h4><span class="material-symbols-rounded">tune</span> ECH</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.vlTr.echTitle"></span></h4>
                             <div class="form-control">
-                                <label for="enableECH">🎭 ECH</label>
+                                <label for="enableECH" data-i18n="panel.vlTr.enableECH"></label>
                                 <div>
                                     <select id="enableECH" name="enableECH">
-                                        <option value="true">Enabled</option>
-                                        <option value="false">Disabled</option>
+                                        <option value="true" data-i18n="common.enabled"></option>
+                                        <option value="false" data-i18n="common.disabled"></option>
                                     </select>
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="echServerName">🧢 ECH Server Name</label>
+                                <label for="echServerName" data-i18n="panel.vlTr.echServerName"></label>
                                 <div>
                                     <input type="text" id="echServerName" name="echServerName">
                                 </div>
@@ -208,9 +208,9 @@
                     </div>
                     <div class="container">
                         <div class="section">
-                            <h4><span class="material-symbols-rounded">tune</span> Proxy IP</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.vlTr.proxyIPTitle"></span></h4>
                             <div class="form-control">
-                                <label for="proxyIPMode">🎚️ Mode</label>
+                                <label for="proxyIPMode" data-i18n="panel.vlTr.mode"></label>
                                 <div>
                                     <select id="proxyIPMode" name="proxyIPMode">
                                         <option value="proxyip">Proxy IP</option>
@@ -220,8 +220,8 @@
                             </div>
                             <div class="form-control">
                                 <label for="proxyIPs">
-                                    📍 Proxy IPs / Domains
-                                    <a class="scanner" href="/proxy-ip" title="Proxy IPs" target="_blank"
+                                    <span data-i18n="panel.vlTr.proxyIPs"></span>
+                                    <a class="scanner" href="/proxy-ip" data-i18n-title="panel.vlTr.proxyIPsLink" target="_blank"
                                         rel="noopener noreferrer">
                                         <span class="material-symbols-rounded">open_in_new</span>
                                     </a>
@@ -232,10 +232,10 @@
                             </div>
                             <div class="form-control">
                                 <label for="prefixes">
-                                    📍 NAT64 Prefixes
+                                    <span data-i18n="panel.vlTr.nat64Prefixes"></span>
                                     <a class="scanner"
                                         href="https://github.com/bia-pain-bache/BPB-Worker-Panel/blob/main/docs/NAT64Prefixes.md"
-                                        title="NAT64 prefixes" target="_blank" rel="noopener noreferrer">
+                                        data-i18n-title="panel.vlTr.nat64PrefixesLink" target="_blank" rel="noopener noreferrer">
                                         <span class="material-symbols-rounded">open_in_new</span>
                                     </a>
                                 </label>
@@ -247,21 +247,21 @@
                     </div>
                     <div class="container">
                         <div class="section">
-                            <h4><span class="material-symbols-rounded">tune</span> Custom CDN</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.vlTr.customCdnTitle"></span></h4>
                             <div class="form-control">
-                                <label for="customCdnAddrs">💀 Addresses</label>
+                                <label for="customCdnAddrs" data-i18n="panel.vlTr.addresses"></label>
                                 <div>
                                     <textarea type="text" id="customCdnAddrs" name="customCdnAddrs" rows="1"></textarea>
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="customCdnHost">💀 Host</label>
+                                <label for="customCdnHost" data-i18n="panel.vlTr.host"></label>
                                 <div>
                                     <input type="text" id="customCdnHost" name="customCdnHost">
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="customCdnSni">💀 SNI</label>
+                                <label for="customCdnSni" data-i18n="panel.vlTr.sni"></label>
                                 <div>
                                     <input type="text" id="customCdnSni" name="customCdnSni">
                                 </div>
@@ -272,28 +272,28 @@
             </details>
             <details>
                 <summary>
-                    <h3>Xray Fragment
+                    <h3><span data-i18n="panel.fragment.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/fragment/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="form-control">
-                        <label for="fragmentMode">🎚️ Mode</label>
+                        <label for="fragmentMode" data-i18n="panel.fragment.mode"></label>
                         <div>
                             <select id="fragmentMode" name="fragmentMode" onchange="handleFragmentMode()">
-                                <option value="custom">Custom</option>
-                                <option value="low">Low</option>
-                                <option value="medium">Medium</option>
-                                <option value="high">High</option>
-                                <option value="severe">Severe</option>
+                                <option value="custom" data-i18n="panel.fragment.modeCustom"></option>
+                                <option value="low" data-i18n="panel.fragment.modeLow"></option>
+                                <option value="medium" data-i18n="panel.fragment.modeMedium"></option>
+                                <option value="high" data-i18n="panel.fragment.modeHigh"></option>
+                                <option value="severe" data-i18n="panel.fragment.modeSevere"></option>
                             </select>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fragmentLengthMin">📐 Length</label>
+                        <label for="fragmentLengthMin" data-i18n="panel.fragment.length"></label>
                         <div class="min-max">
                             <input type="number" id="fragmentLengthMin" name="fragmentLengthMin" min="1" required>
                             <span>-</span>
@@ -301,7 +301,7 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fragmentIntervalMin">🕞 Interval</label>
+                        <label for="fragmentIntervalMin" data-i18n="panel.fragment.interval"></label>
                         <div class="min-max">
                             <input type="number" id="fragmentIntervalMin" name="fragmentIntervalMin" min="1" max="30"
                                 required>
@@ -311,7 +311,7 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fragmentMaxSplitMin">⛓️ Max Split</label>
+                        <label for="fragmentMaxSplitMin" data-i18n="panel.fragment.maxSplit"></label>
                         <div class="min-max">
                             <input type="number" id="fragmentMaxSplitMin" name="fragmentMaxSplitMin" min="2">
                             <span>-</span>
@@ -319,7 +319,7 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="fragmentPackets">📦 Packets</label>
+                        <label for="fragmentPackets" data-i18n="panel.fragment.packets"></label>
                         <div>
                             <select id="fragmentPackets" name="fragmentPackets">
                                 <option value="tlshello">tlshello</option>
@@ -334,22 +334,22 @@
             </details>
             <details>
                 <summary>
-                    <h3>External Raw Configs
+                    <h3><span data-i18n="panel.externalRaw.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/external-configs/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="form-control">
-                        <label for="customSubs">🔗 Subscriptions</label>
+                        <label for="customSubs" data-i18n="panel.externalRaw.subscriptions"></label>
                         <div>
                             <textarea type="text" id="customSubs" name="customSubs" rows="1" wrap="off"></textarea>
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="customConfigs">➕ Single Configs</label>
+                        <label for="customConfigs" data-i18n="panel.externalRaw.singleConfigs"></label>
                         <div>
                             <textarea type="text" id="customConfigs" name="customConfigs" rows="1" wrap="off"></textarea>
                         </div>
@@ -358,24 +358,24 @@
             </details>
             <details>
                 <summary>
-                    <h3>Warp General
+                    <h3><span data-i18n="panel.warpGeneral.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/warp/" target="_blank"
-                            title="Help">
+                            data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="form-control">
-                        <label for="warpRemoteDNS">🌏 remote DNS</label>
+                        <label for="warpRemoteDNS" data-i18n="panel.warpGeneral.remoteDNS"></label>
                         <div>
                             <input type="text" id="warpRemoteDNS" name="warpRemoteDNS" required>
                         </div>
                     </div>
                     <div class="form-control">
                         <label for="warpEndpoints">
-                            ✨ Endpoints
-                            <a class="scanner" href="https://github.com/bia-pain-bache/BPB-Warp-Scanner" title="Scanner"
+                            <span data-i18n="panel.warpGeneral.endpoints"></span>
+                            <a class="scanner" href="https://github.com/bia-pain-bache/BPB-Warp-Scanner" data-i18n-title="panel.vlTr.scannerTitle"
                                 target="_blank" rel="noopener noreferrer">
                                 <span class="material-symbols-rounded">open_in_new</span>
                             </a>
@@ -385,16 +385,16 @@
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="bestWarpInterval">🔄 Best Interval</label>
+                        <label for="bestWarpInterval" data-i18n="panel.warpGeneral.bestInterval"></label>
                         <div>
                             <input type="number" id="bestWarpInterval" name="bestWarpInterval" min="10" max="90">
                         </div>
                     </div>
                     <div class="form-control">
-                        <label for="refreshBtn">♻️ Warp Accounts</label>
+                        <label for="refreshBtn" data-i18n="panel.warpGeneral.warpAccounts"></label>
                         <div>
                             <button type="button" class="button reverse" onclick="updateWarpConfigs()">
-                                Update<span id="warp-update" class="material-symbols-rounded">autorenew</span>
+                                <span data-i18n="common.update"></span><span id="warp-update" class="material-symbols-rounded">autorenew</span>
                             </button>
                         </div>
                     </div>
@@ -402,9 +402,9 @@
             </details>
             <details>
                 <summary>
-                    <h3>Warp PRO
+                    <h3><span data-i18n="panel.warpPro.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/warp-pro/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
@@ -412,17 +412,16 @@
                 <div class="section">
                     <div class="container">
                         <div class="section">
-                            <h4><span class="material-symbols-rounded">tune</span> MahsaNG Noise</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.warpPro.mahsaNoise"></span></h4>
                             <div class="form-control">
-                                <label for="knockerNoiseMode">😵‍💫 Mode</label>
+                                <label for="knockerNoiseMode" data-i18n="panel.warpPro.knockerMode"></label>
                                 <div>
                                     <input type="text" id="knockerNoiseMode" name="knockerNoiseMode"
-                                        title="Fill in 'none', 'quic', 'random', or any HEX string like 'ee0000000108aaaa'"
-                                        required>
+                                        data-i18n-title="panel.warpPro.knockerModeTip" required>
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="noiseCountMin">🎚️ Count</label>
+                                <label for="noiseCountMin" data-i18n="panel.warpPro.count"></label>
                                 <div class="min-max">
                                     <input type="number" id="noiseCountMin" name="noiseCountMin" min="1" required>
                                     <span>-</span>
@@ -430,7 +429,7 @@
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="noiseSizeMin">📏 Size</label>
+                                <label for="noiseSizeMin" data-i18n="panel.warpPro.size"></label>
                                 <div class="min-max">
                                     <input type="number" id="noiseSizeMin" name="noiseSizeMin" min="1" required>
                                     <span>-</span>
@@ -438,7 +437,7 @@
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="noiseDelayMin">🕞 Delay</label>
+                                <label for="noiseDelayMin" data-i18n="panel.warpPro.delay"></label>
                                 <div class="min-max">
                                     <input type="number" id="noiseDelayMin" name="noiseDelayMin" min="1" required>
                                     <span>-</span>
@@ -449,16 +448,16 @@
                     </div>
                     <div class="container">
                         <div class="section">
-                            <h4><span class="material-symbols-rounded">tune</span> Clash - Amnezia Noise</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.warpPro.clashAmnezia"></span></h4>
                             <div class="form-control">
-                                <label for="amneziaNoiseCount">🎚️ Count</label>
+                                <label for="amneziaNoiseCount" data-i18n="panel.warpPro.count"></label>
                                 <div>
                                     <input type="number" id="amneziaNoiseCount" name="amneziaNoiseCount" min="1"
                                         required>
                                 </div>
                             </div>
                             <div class="form-control">
-                                <label for="amneziaNoiseSizeMin">📏 Size</label>
+                                <label for="amneziaNoiseSizeMin" data-i18n="panel.warpPro.size"></label>
                                 <div class="min-max">
                                     <input type="number" id="amneziaNoiseSizeMin" name="amneziaNoiseSizeMin" min="1"
                                         required>
@@ -471,7 +470,7 @@
                     </div>
                     <div id="udp-noise-container" class="container">
                         <div class="header-container">
-                            <h4><span class="material-symbols-rounded">tune</span> v2rayNG - v2rayN Noise</h4>
+                            <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.warpPro.v2rayNoise"></span></h4>
                             <button type="button" class="add-noise" onclick="addUdpNoise(true)">
                                 <span class="material-symbols-rounded">add_circle</span>
                             </button>
@@ -482,90 +481,90 @@
             </details>
             <details>
                 <summary>
-                    <h3>Routing Rules
+                    <h3><span data-i18n="panel.routing.title"></span>
                         <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/configuration/routing-rules/"
-                            target="_blank" title="Help">
+                            target="_blank" data-i18n-title="common.help">
                             <span class="material-symbols-rounded">info</span>
                         </a>
                     </h3>
                 </summary>
                 <div class="section">
                     <div class="container">
-                        <h4><span class="material-symbols-rounded">tune</span> Preset Rules</h4>
+                        <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.routing.preset"></span></h4>
                         <div class="form-control">
-                            <label for="bypass-rules">🟩 Bypass rules</label>
+                            <label for="bypass-rules" data-i18n="panel.routing.bypassRules"></label>
                             <div>
                                 <div id="bypass-rules" class="rules inner-container">
                                     <div class="routing">
                                         <input type="checkbox" id="bypassIran" name="bypassIran" value="true">
-                                        <label for="bypassIran">Iran</label>
+                                        <label for="bypassIran" data-i18n="panel.routing.iran"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="bypassChina" name="bypassChina" value="true">
-                                        <label for="bypassChina">China</label>
+                                        <label for="bypassChina" data-i18n="panel.routing.china"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="bypassRussia" name="bypassRussia" value="true">
-                                        <label for="bypassRussia">Russia</label>
+                                        <label for="bypassRussia" data-i18n="panel.routing.russia"></label>
                                     </div>
                                 </div>
                             </div>
                         </div>
                         <div class="form-control">
-                            <label for="block-rules">🟥 Block rules</label>
+                            <label for="block-rules" data-i18n="panel.routing.blockRules"></label>
                             <div>
                                 <div id="block-rules" class="rules inner-container">
                                     <div class="routing">
                                         <input type="checkbox" id="blockAds" name="blockAds" value="true">
-                                        <label for="blockAds">Ads.</label>
+                                        <label for="blockAds" data-i18n="panel.routing.ads"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="blockPorn" name="blockPorn" value="true">
-                                        <label for="blockPorn">Porn</label>
+                                        <label for="blockPorn" data-i18n="panel.routing.porn"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="blockUDP443" name="blockUDP443" value="true">
-                                        <label for="blockUDP443">QUIC</label>
+                                        <label for="blockUDP443" data-i18n="panel.routing.quic"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="blockMalware" name="blockMalware" value="true"
                                             onchange="handleRiskyRules(event)">
-                                        <label for="blockMalware">Malware</label>
+                                        <label for="blockMalware" data-i18n="panel.routing.malware"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="blockPhishing" name="blockPhishing" value="true"
                                             onchange="handleRiskyRules(event)">
-                                        <label for="blockPhishing">Phishing</label>
+                                        <label for="blockPhishing" data-i18n="panel.routing.phishing"></label>
                                     </div>
                                     <div class="routing">
                                         <input type="checkbox" id="blockCryptominers" name="blockCryptominers"
                                             value="true" onchange="handleRiskyRules(event)">
-                                        <label for="blockCryptominers">Cryptominers</label>
+                                        <label for="blockCryptominers" data-i18n="panel.routing.cryptominers"></label>
                                     </div>
                                 </div>
                             </div>
                         </div>
                     </div>
                     <div class="container">
-                        <h4><span class="material-symbols-rounded">tune</span> Custom Rules</h4>
+                        <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.routing.custom"></span></h4>
                         <div class="form-control">
-                            <label for="customBypassRules">🟩 Bypass IPs / Domains</label>
+                            <label for="customBypassRules" data-i18n="panel.routing.customBypass"></label>
                             <div>
                                 <textarea type="text" id="customBypassRules" name="customBypassRules"
                                     rows="1"></textarea>
                             </div>
                         </div>
                         <div class="form-control">
-                            <label for="customBlockRules">🟥 Block IPs / Domains</label>
+                            <label for="customBlockRules" data-i18n="panel.routing.customBlock"></label>
                             <div>
                                 <textarea type="text" id="customBlockRules" name="customBlockRules" rows="1"></textarea>
                             </div>
                         </div>
                     </div>
                     <div class="container">
-                        <h4><span class="material-symbols-rounded">tune</span> Sanction Rules</h4>
+                        <h4><span class="material-symbols-rounded">tune</span> <span data-i18n="panel.routing.sanction"></span></h4>
                         <div class="form-control">
-                            <label for="bypass-sanction-rules">🟩 Bypass rules</label>
+                            <label for="bypass-sanction-rules" data-i18n="panel.routing.sanctionBypass"></label>
                             <div>
                                 <div id="bypass-sanction-rules" class="rules inner-container">
                                     <div class="routing">
@@ -624,7 +623,7 @@
                             </div>
                         </div>
                         <div class="form-control">
-                            <label for="customBypassSanctionRules">🟩 Bypass Domains</label>
+                            <label for="customBypassSanctionRules" data-i18n="panel.routing.sanctionBypassDomains"></label>
                             <div>
                                 <textarea type="text" id="customBypassSanctionRules" name="customBypassSanctionRules"
                                     rows="1"></textarea>
@@ -635,16 +634,16 @@
             </details>
             <div id="apply" class="form-control apply">
                 <button type="submit" id="applyButton" class="button disabled apply-settings" form="configForm">
-                    Apply <span class="material-symbols-rounded">check_circle</span>
+                    <span data-i18n="common.apply"></span> <span class="material-symbols-rounded">check_circle</span>
                 </button>
-                <button type="button" class="panel-settings" title="Reset panel settings to default"
+                <button type="button" class="panel-settings" data-i18n-title="panel.apply.reset"
                     onclick="resetSettings()">
                     <i id="refresh-btn" class="fa fa-refresh fa-2x" aria-hidden="true"></i>
                 </button>
-                <button type="button" class="panel-settings" title="Export panel settings" onclick="exportSettings()">
+                <button type="button" class="panel-settings" data-i18n-title="panel.apply.export" onclick="exportSettings()">
                     <i class="fa fa-cloud-download fa-2x" aria-hidden="true"></i>
                 </button>
-                <button type="button" class="panel-settings" title="Import panel settings" onclick="importSettings()">
+                <button type="button" class="panel-settings" data-i18n-title="panel.apply.import" onclick="importSettings()">
                     <i class="fa fa-cloud-upload fa-2x" aria-hidden="true"></i>
                     <input type="file" id="fileInput" accept=".dat" style="display: none;"
                         onchange="uploadSettings(event)" />
@@ -653,12 +652,12 @@
         </form>
     </div>
     <div class="form-container container">
-        <h2><span class="material-symbols-rounded">share</span> Subscriptions</h2>
+        <h2><span class="material-symbols-rounded">share</span> <span data-i18n="panel.sub.title"></span></h2>
         <details>
             <summary>
-                <h3>Normal
+                <h3><span data-i18n="panel.sub.normal"></span>
                     <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/normal/" target="_blank"
-                        title="Help">
+                        data-i18n-title="common.help">
                         <span class="material-symbols-rounded">info</span>
                     </a>
                 </h3>
@@ -689,14 +688,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('normal', 'xray', 'Normal', 'Normal Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('normal', 'xray', 'Normal', t('panel.sub.normalSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('normal', 'xray', 'Normal')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('normal', 'xray', 'Normal')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('normal', 'xray')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('normal', 'xray')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -713,14 +712,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('normal', 'sing-box', 'Normal', 'Normal Subscription', true)">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('normal', 'sing-box', 'Normal', t('panel.sub.normalSub'), true)">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('normal', 'sing-box', 'Normal')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('normal', 'sing-box', 'Normal')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('normal', 'sing-box')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('normal', 'sing-box')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -749,14 +748,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('normal', 'clash', 'Normal', 'Normal Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('normal', 'clash', 'Normal', t('panel.sub.normalSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('normal', 'clash', 'Normal')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('normal', 'clash', 'Normal')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('normal', 'clash')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('normal', 'clash')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -766,9 +765,9 @@
         </details>
         <details>
             <summary>
-                <h3>Fragment
+                <h3><span data-i18n="panel.sub.fragment"></span>
                     <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/fragment/" target="_blank"
-                        title="Help">
+                        data-i18n-title="common.help">
                         <span class="material-symbols-rounded">info</span>
                     </a>
                 </h3>
@@ -799,14 +798,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('fragment', 'xray', 'Fragment', 'Fragment Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('fragment', 'xray', 'Fragment', t('panel.sub.fragmentSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('fragment', 'xray', 'Fragment')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('fragment', 'xray', 'Fragment')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('fragment', 'xray')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('fragment', 'xray')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -823,14 +822,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('fragment', 'sing-box', 'Fragment', 'Fragment Subscription', true)">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('fragment', 'sing-box', 'Fragment', t('panel.sub.fragmentSub'), true)">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('fragment', 'sing-box', 'Fragment')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('fragment', 'sing-box', 'Fragment')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('fragment', 'sing-box')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('fragment', 'sing-box')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -841,8 +840,8 @@
         <details class="details">
             <summary>
                 <h3>
-                    Raw (without settings)
-                    <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/raw/" target="_blank" title="Help">
+                    <span data-i18n="panel.sub.raw"></span>
+                    <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/raw/" target="_blank" data-i18n-title="common.help">
                         <span class="material-symbols-rounded">info</span>
                     </a>
                 </h3>
@@ -881,10 +880,10 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code" onclick="openQR('raw', 'xray', 'Raw', 'Raw Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle" onclick="openQR('raw', 'xray', 'Raw', t('panel.sub.rawSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('raw', 'xray', 'Raw')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('raw', 'xray', 'Raw')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
                         </td>
@@ -913,11 +912,11 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('raw', 'sing-box', 'Raw', 'Raw Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('raw', 'sing-box', 'Raw', t('panel.sub.rawSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('raw', 'sing-box', 'Raw')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('raw', 'sing-box', 'Raw')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
                         </td>
@@ -927,9 +926,9 @@
         </details>
         <details>
             <summary>
-                <h3>Warp
+                <h3><span data-i18n="panel.sub.warp"></span>
                     <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/warp/" target="_blank"
-                        title="Help">
+                        data-i18n-title="common.help">
                         <span class="material-symbols-rounded">info</span>
                     </a>
                 </h3>
@@ -952,14 +951,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp', 'xray', 'Warp', 'Warp Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp', 'xray', 'Warp', t('panel.sub.warpSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('warp', 'xray', 'Warp')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('warp', 'xray', 'Warp')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp', 'xray')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp', 'xray')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -976,14 +975,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp', 'sing-box', 'Warp', 'Warp Subscription', true)">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp', 'sing-box', 'Warp', t('panel.sub.warpSub'), true)">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('warp', 'sing-box', 'Warp')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('warp', 'sing-box', 'Warp')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp', 'sing-box')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp', 'sing-box')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -1012,14 +1011,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp', 'clash', 'Warp', 'Warp Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp', 'clash', 'Warp', t('panel.sub.warpSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('warp', 'clash', 'Warp')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('warp', 'clash', 'Warp')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp', 'clash')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp', 'clash')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -1032,7 +1031,7 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Download configs zip" id="dlConfigsBtn" type="button"
+                            <button data-i18n-title="panel.sub.dlZipTitle" id="dlConfigsBtn" type="button"
                                 onclick="downloadWarpConfigs(false)">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
@@ -1043,9 +1042,9 @@
         </details>
         <details>
             <summary>
-                <h3>Warp PRO
+                <h3><span data-i18n="panel.sub.warpPro"></span>
                     <a href="https://bia-pain-bache.github.io/BPB-Worker-Panel/usage/warp-pro/" target="_blank"
-                        title="Help">
+                        data-i18n-title="common.help">
                         <span class="material-symbols-rounded">info</span>
                     </a>
                 </h3>
@@ -1068,14 +1067,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp-pro', 'xray', 'Warp Pro', 'Warp Pro Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp-pro', 'xray', 'Warp Pro', t('panel.sub.warpProSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('warp-pro', 'xray', 'Warp Pro')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('warp-pro', 'xray', 'Warp Pro')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp-pro', 'xray')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp-pro', 'xray')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -1092,15 +1091,15 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp-pro', 'xray-knocker', 'Warp Pro', 'Warp Pro Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp-pro', 'xray-knocker', 'Warp Pro', t('panel.sub.warpProSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL"
+                            <button data-i18n-title="panel.sub.copyTitle"
                                 onclick="subURL('warp-pro', 'xray-knocker', 'Warp Pro')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp-pro', 'xray-knocker')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp-pro', 'xray-knocker')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -1129,14 +1128,14 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Display QR code"
-                                onclick="openQR('warp-pro', 'clash', 'Warp Pro', 'Warp Pro Subscription')">
+                            <button data-i18n-title="panel.sub.qrTitle"
+                                onclick="openQR('warp-pro', 'clash', 'Warp Pro', t('panel.sub.warpProSub'))">
                                 <span class="material-symbols-rounded">qr_code</span>
                             </button>
-                            <button title="Copy subscription URL" onclick="subURL('warp-pro', 'clash', 'Warp Pro')">
+                            <button data-i18n-title="panel.sub.copyTitle" onclick="subURL('warp-pro', 'clash', 'Warp Pro')">
                                 <span class="material-symbols-rounded">content_copy</span>
                             </button>
-                            <button title="Download config" onclick="dlURL('warp-pro', 'clash')">
+                            <button data-i18n-title="panel.sub.dlTitle" onclick="dlURL('warp-pro', 'clash')">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
                         </td>
@@ -1153,7 +1152,7 @@
                             </div>
                         </td>
                         <td>
-                            <button title="Download configs zip" id="dlAmneziaConfigsBtn" type="button"
+                            <button data-i18n-title="panel.sub.dlZipTitle" id="dlAmneziaConfigsBtn" type="button"
                                 onclick="downloadWarpConfigs(true)">
                                 <span class="material-symbols-rounded">download</span>
                             </button>
@@ -1164,7 +1163,7 @@
         </details>
     </div>
     <div class="form-container container">
-        <h2><span class="material-symbols-rounded">dns</span> DNS over HTTPS</h2>
+        <h2><span class="material-symbols-rounded">dns</span> <span data-i18n="panel.doh"></span></h2>
         <div class="value-container">
             <div class="output-container">
                 <span id="doh" class="output"></span>
@@ -1180,10 +1179,10 @@
             <div class="modal-content">
                 <span class="close" id="closeResetPass" onclick="closeResetPass()">&times;</span>
                 <form id="passwordChangeForm" onsubmit="resetPassword(event)">
-                    <h2>Change Password</h2>
+                    <h2 data-i18n="panel.pwd.title"></h2>
                     <div class="section">
                         <div class="form-control">
-                            <label for="newPassword">New Password</label>
+                            <label for="newPassword" data-i18n="panel.pwd.newPwd"></label>
                             <div class="password-wrapper">
                                 <input type="password" id="newPassword" name="newPassword" required>
                                 <span class="material-symbols-rounded toggle-password">
@@ -1192,7 +1191,7 @@
                             </div>
                         </div>
                         <div class="form-control">
-                            <label for="confirmPassword">Confirm Password</label>
+                            <label for="confirmPassword" data-i18n="panel.pwd.confirmPwd"></label>
                             <div class="password-wrapper">
                                 <input type="password" id="confirmPassword" name="confirmPassword" required>
                                 <span class="material-symbols-rounded toggle-password">
@@ -1202,7 +1201,7 @@
                         </div>
                     </div>
                     <div id="passwordError" class="password-error"></div>
-                    <button id="changePasswordBtn" type="submit" class="button">Change Password</button>
+                    <button id="changePasswordBtn" type="submit" class="button" data-i18n="panel.pwd.submit"></button>
                 </form>
             </div>
         </div>
@@ -1216,7 +1215,7 @@
             </div>
         </div>
         <div class="header-container">
-            <h2><span class="material-symbols-rounded">fingerprint</span> My IP</h2>
+            <h2><span class="material-symbols-rounded">fingerprint</span> <span data-i18n="panel.myIp.title"></span></h2>
             <button type="button" id="refresh-geo-location" class="refresh-geo-location" onclick="fetchIPInfo()">
                 <i class="fa fa-refresh fa-2x refresh-my-ip" aria-hidden="true"></i>
             </button>
@@ -1224,28 +1223,28 @@
         <div class="my-ip">
             <table id="ips" class="my-ip">
                 <thead>
-                    <th>Information</th>
-                    <th>Cloudflare targets</th>
-                    <th>Other targets</th>
+                    <th data-i18n="panel.myIp.info"></th>
+                    <th data-i18n="panel.myIp.cf"></th>
+                    <th data-i18n="panel.myIp.other"></th>
                 </thead>
                 <tbody>
                     <tr>
-                        <td>IP</td>
+                        <td data-i18n="panel.myIp.ip"></td>
                         <td id="cf-ip"></td>
                         <td id="ip"></td>
                     </tr>
                     <tr>
-                        <td>Country</td>
+                        <td data-i18n="panel.myIp.country"></td>
                         <td id="cf-country"></td>
                         <td id="country"></td>
                     </tr>
                     <tr>
-                        <td>City</td>
+                        <td data-i18n="panel.myIp.city"></td>
                         <td id="cf-city"></td>
                         <td id="city"></td>
                     </tr>
                     <tr>
-                        <td>ISP</td>
+                        <td data-i18n="panel.myIp.isp"></td>
                         <td id="cf-isp"></td>
                         <td id="isp"></td>
                     </tr>
@@ -1260,9 +1259,9 @@
                 <a class="link" id="github-link" href="https://github.com/bia-pain-bache/BPB-Worker-Panel"
                     target="_blank">Github</a>
             </div>
-            <button id="openResetPass" class="button" onclick="openResetPass()">Change Password <span
+            <button id="openResetPass" class="button" onclick="openResetPass()"><span data-i18n="panel.footer.changePwd"></span> <span
                     class="material-symbols-rounded">key_vertical</span></button>
-            <button type="button" id="logout" class="logout" title="Log out" onclick="logout(event)">
+            <button type="button" id="logout" class="logout" data-i18n-title="panel.footer.logoutTitle" onclick="logout(event)">
                 <i class="fa fa-power-off fa-2x" aria-hidden="true"></i>
             </button>
         </div>
@@ -1271,12 +1270,14 @@
     <button id="darkModeToggle" class="floating-button" onclick="darkModeToggle()">
         <i id="modeIcon" class="fa fa-2x fa-adjust dark-mode" aria-hidden="true"></i>
     </button>
+    <button id="langToggle" class="floating-button lang-toggle" onclick="toggleLang()">中</button>
 
     <script type="module" defer>
         import { polyfillCountryFlagEmojis } from "https://cdn.skypack.dev/country-flag-emoji-polyfill";
         polyfillCountryFlagEmojis();
     </script>
     <script src="https://cdnjs.cloudflare.com/ajax/libs/qrcodejs/1.0.0/qrcode.min.js"></script>
+    <script>__I18N__</script>
     <script>__SCRIPT__</script>
 </body>
 

--- a/src/assets/panel/script.js
+++ b/src/assets/panel/script.js
@@ -184,7 +184,7 @@ async function fetchIPInfo() {
 
     try {
         const response = await fetch('https://ipv4.geojs.io/v1/ip.json' + '?nocache=' + Date.now(), { cache: "no-store" });
-        
+
         if (!response.ok) {
             const errorMessage = await response.text();
             throw new Error(`Fetch Other targets IP failed with status ${response.status} at ${response.url} - ${errorMessage}`);
@@ -320,12 +320,12 @@ function openQR(path, app, tag, title, singboxType) {
 
 function copyToClipboard(text) {
     navigator.clipboard.writeText(text)
-        .then(() => alert('✅ Copied to clipboard:\n\n' + text))
+        .then(() => alert(t('panel.alert.copied', { text })))
         .catch(error => console.error('Failed to copy:', error));
 }
 
 async function updateWarpConfigs() {
-    const confirmReset = confirm('⚠️ Are you sure?');
+    const confirmReset = confirm(t('panel.alert.warpConfirm'));
     if (!confirmReset) return;
     const refreshBtn = document.getElementById('warp-update');
     document.body.style.cursor = 'wait';
@@ -339,15 +339,12 @@ async function updateWarpConfigs() {
         refreshBtn.classList.remove('fa-spin');
 
         if (!success) {
-            alert(
-                '⚠️ An error occured, Please try again!\n' +
-                `⛔ ${message}`
-            );
+            alert(t('panel.alert.warpFail', { message }));
 
             throw new Error(`status ${status} - ${message}`);
         }
 
-        alert('✅ Warp configs updated successfully!');
+        alert(t('panel.alert.warpSuccess'));
     } catch (error) {
         console.error("Updating Warp configs error:", error.message || error)
     }
@@ -364,7 +361,7 @@ function handleProtocolChange(event) {
     if (globalThis.activeProtocols === 0) {
         event.preventDefault();
         event.target.checked = !event.target.checked;
-        alert("⛔ At least one Protocol should be selected!");
+        alert(t('panel.alert.needOneProtocol'));
         globalThis.activeProtocols++;
         return false;
     }
@@ -383,7 +380,7 @@ function handlePortChange(event) {
     if (globalThis.activeTlsPorts.length === 0) {
         event.preventDefault();
         event.target.checked = !event.target.checked;
-        alert("⛔ At least one TLS port should be selected!");
+        alert(t('panel.alert.needOneTlsPort'));
         globalThis.activeTlsPorts.push(portField);
         return false;
     }
@@ -391,10 +388,7 @@ function handlePortChange(event) {
 
 function handleRiskyRules(event) {
     if (event.target.checked) {
-        const proceed = confirm(
-            "⛔ v2ray users should set Geo Assets to Chocolate4U and download assets, otherwise configs won't connect.\n\n" +
-            "❓ Proceed?"
-        );
+        const proceed = confirm(t('panel.alert.riskyRules'));
 
         if (!proceed) {
             event.target.checked = false;
@@ -431,7 +425,7 @@ function handleFragmentMode() {
 }
 
 function resetSettings() {
-    const confirmReset = confirm('⚠️ This will reset all panel settings.\n\n❓ Are you sure?');
+    const confirmReset = confirm(t('panel.alert.resetConfirm'));
     if (!confirmReset) return;
 
     const resetBtn = document.getElementById("refresh-btn");
@@ -455,7 +449,7 @@ function resetSettings() {
             }
 
             initiatePanel(body);
-            alert('✅ Panel settings reset to default successfully!\n💡 Please update your subscriptions.');
+            alert(t('panel.alert.resetSuccess'));
         })
         .catch(error => console.error("Reseting settings error:", error.message || error));
 }
@@ -471,7 +465,7 @@ function updateSettings(event, data) {
     const applyButton = document.getElementById('applyButton');
     document.body.style.cursor = 'wait';
     const applyButtonVal = applyButton.value;
-    applyButton.value = '⌛ Loading...';
+    applyButton.value = t('panel.alert.loading');
 
     fetch('/panel/update-settings', {
         method: 'PUT',
@@ -483,7 +477,7 @@ function updateSettings(event, data) {
         .then(({ success, status, message }) => {
 
             if (status === 401) {
-                alert('⚠️ Session expired! Please login again.');
+                alert(t('panel.alert.sessionExpired'));
                 window.location.href = '/login';
             }
 
@@ -492,7 +486,7 @@ function updateSettings(event, data) {
             }
 
             initiatePanel(form);
-            alert('✅ Settings applied successfully!\n💡 Please update your subscriptions.');
+            alert(t('panel.alert.settingsApplied'));
         })
         .catch(error => console.error("Update settings error:", error.message || error))
         .finally(() => {
@@ -565,7 +559,7 @@ function validateRemoteDNS() {
     try {
         url = new URL(dns);
     } catch (error) {
-        alert("⛔ Invalid DNS, Please enter a URL.");
+        alert(t('panel.alert.invalidDnsUrl'));
         return false;
     }
 
@@ -590,15 +584,12 @@ function validateRemoteDNS() {
     ];
 
     if (!["tcp:", "https:", "tls:"].includes(url.protocol)) {
-        alert("⛔ Please enter TCP, DoH or DoT servers.");
+        alert(t('panel.alert.invalidDnsProto'));
         return false;
     }
 
     if (cloudflareDNS.includes(url.hostname)) {
-        alert(
-            "⛔ Cloudflare DNS is not allowed for workers.\n" +
-            "💡 Please use other public DNS servers like Google, Adguard..."
-        );
+        alert(t('panel.alert.cfDnsForbidden'));
 
         return false;
     }
@@ -620,11 +611,7 @@ function validateSanctionDns() {
     const isValid = isValidHostName(host, false);
 
     if (!isValid) {
-        alert(
-            '⛔ Invalid IPs or Domains.\n' +
-            `⚠️ ${host}`
-        );
-
+        alert(t('panel.alert.invalidHosts', { host }));
         return false;
     }
 
@@ -636,12 +623,7 @@ function validateWarpDNS() {
     const isValid = isIPv4(dns);
 
     if (!isValid) {
-        alert(
-            '⛔ Invalid Warp DNS.\n' +
-            '💡 Please fill in an IPv4 address (UDP DNS).\n\n' +
-            `⚠️ ${dns}`
-        );
-
+        alert(t('panel.alert.invalidWarpDns', { dns }));
         return false;
     }
 
@@ -653,12 +635,7 @@ function validateLocalDNS() {
     const isValid = isIPv4(dns) || dns === 'localhost';
 
     if (!isValid) {
-        alert(
-            '⛔ Invalid local DNS.\n' +
-            '💡 Please fill in an IPv4 address or "localhost".\n\n' +
-            `⚠️ ${dns}`
-        );
-
+        alert(t('panel.alert.invalidLocalDns', { dns }));
         return false;
     }
 
@@ -675,21 +652,16 @@ function validateCustomRules() {
     const invalidDomainValues = parseElmValues('customBypassSanctionRules').filter(value => !isDomain(value));
 
     if (invalidDomainIpValues.length) {
-        alert(
-            '⛔ Invalid IPs, Domains or IP ranges.\n' +
-            '💡 Please enter each value in a new line.\n\n' +
-            invalidDomainIpValues.map(val => `⚠️ ${val}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidIpDomainList', {
+            list: invalidDomainIpValues.map(val => `⚠️ ${val}`).join('\n')
+        }));
         return false;
     }
 
     if (invalidDomainValues.length) {
-        alert(
-            '⛔ Invalid Domains.\n💡 Please enter each value in a new line.\n\n' +
-            invalidDomainValues.map(val => `⚠️ ${val}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidDomainList', {
+            list: invalidDomainValues.map(val => `⚠️ ${val}`).join('\n')
+        }));
         return false;
     }
 
@@ -706,12 +678,9 @@ function validateMultipleHostNames() {
         .filter(value => !isValidHostName(value));
 
     if (invalidValues.length) {
-        alert(
-            '⛔ Invalid IPs or Domains.\n' +
-            '💡 Please enter each value in a new line.\n\n' +
-            invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidIpDomainListShort', {
+            list: invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
+        }));
         return false;
     }
 
@@ -723,12 +692,9 @@ function validateProxyIPs() {
         .filter(value => !isValidHostName(value));
 
     if (invalidValues.length) {
-        alert(
-            '⛔ Invalid proxy IPs.\n' +
-            '💡 Please enter each value in a new line.\n\n' +
-            invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidProxyIPs', {
+            list: invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
+        }));
         return false;
     }
 
@@ -740,12 +706,9 @@ function validateNAT64Prefixes() {
         .filter(value => !isIPv6(value));
 
     if (invalidValues.length) {
-        alert(
-            '⛔ Invalid NAT64 prefix.\n' +
-            '💡 Please enter each prefix in a new line using [].\n\n' +
-            invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidNat64', {
+            list: invalidValues.map(ip => `⚠️ ${ip}`).join('\n')
+        }));
         return false;
     }
 
@@ -757,11 +720,9 @@ function validateWarpEndpoints() {
         .filter(value => !isValidHostName(value, true));
 
     if (invalidEndpoints.length) {
-        alert(
-            '⛔ Invalid endpoint.\n\n' +
-            invalidEndpoints.map(endpoint => `⚠️ ${endpoint}`).join('\n')
-        );
-
+        alert(t('panel.alert.invalidEndpoint', {
+            list: invalidEndpoints.map(endpoint => `⚠️ ${endpoint}`).join('\n')
+        }));
         return false;
     }
 
@@ -772,21 +733,21 @@ function validateMinMax() {
     const getValue = (id) => parseInt(getElmValue(id), 10);
 
     const fields = [
-        ['fragmentLengthMin', 'fragmentLengthMax', 'Fragment Length'],
-        ['fragmentIntervalMin', 'fragmentIntervalMax', 'Fragment Interval'],
-        ['fragmentMaxSplitMin', 'fragmentMaxSplitMax', 'Fragment Max Split'],
-        ['noiseCountMin', 'noiseCountMax', 'Noise Count'],
-        ['noiseSizeMin', 'noiseSizeMax', 'Noise Size'],
-        ['noiseDelayMin', 'noiseDelayMax', 'Noise Delay'],
-        ['amneziaNoiseSizeMin', 'amneziaNoiseSizeMax', 'Amnezia Noise Size']
+        ['fragmentLengthMin', 'fragmentLengthMax', 'panel.fragLabel'],
+        ['fragmentIntervalMin', 'fragmentIntervalMax', 'panel.fragInterval'],
+        ['fragmentMaxSplitMin', 'fragmentMaxSplitMax', 'panel.fragMaxSplit'],
+        ['noiseCountMin', 'noiseCountMax', 'panel.noiseCount'],
+        ['noiseSizeMin', 'noiseSizeMax', 'panel.noiseSize'],
+        ['noiseDelayMin', 'noiseDelayMax', 'panel.noiseDelay'],
+        ['amneziaNoiseSizeMin', 'amneziaNoiseSizeMax', 'panel.amneziaSize']
     ];
 
-    for (const [minId, maxId, label] of fields) {
+    for (const [minId, maxId, labelKey] of fields) {
         const min = getValue(minId);
         const max = getValue(maxId);
 
         if (min > max) {
-            alert(`⛔ ${label}: Minimum cannot be bigger than Maximum!`);
+            alert(t('panel.alert.minMax', { label: t(labelKey) }));
             return false;
         }
     }
@@ -801,17 +762,7 @@ function validateChainProxy() {
     const isOthers = /(http|socks|socks5|vless|trojan|ss):\/\/[^\s@]+@[^\s:]+:[^\s]+/.test(chainProxy);
 
     if (!isVMess && !isOthers) {
-        alert(
-            '⛔ Invalid Config!\n' +
-            '💡 Standard formats are:\n\n' +
-            ' + (socks or socks5 or http)://user:pass@server:port\n' +
-            ' + (socks or socks5 or http)://base64@server:port\n' +
-            ' + vless://uuid@server:port...\n' +
-            ' + vmess://base64\n' +
-            ' + trojan://password@server:port...\n' +
-            ' + ss://base64@server:port...'
-        );
-
+        alert(t('panel.alert.invalidConfig'));
         return false;
     }
 
@@ -829,29 +780,17 @@ function validateChainProxy() {
 
     if (['vless:', 'trojan:', 'vmess:'].includes(protocol)) {
         if (!username) {
-            alert(
-                '⛔ Invalid Config!\n' +
-                '💡 Config URL should contain UUID or Password.'
-            );
-
+            alert(t('panel.alert.configNoUser'));
             return false;
         }
 
         if (security && !['tls', 'none', 'reality'].includes(security)) {
-            alert(
-                '⛔ Invalid Config!\n' +
-                '💡 VLESS, VMess or Trojan security can be TLS, Reality or None.'
-            );
-
+            alert(t('panel.alert.configBadSec'));
             return false;
         }
 
         if (!['tcp', 'raw', 'ws', 'grpc', 'httpupgrade'].includes(type)) {
-            alert(
-                '⛔ Invalid Config!\n' +
-                '💡 VLESS, VMess or Trojan transmission can be tcp, ws, grpc or httpupgrade.'
-            );
-
+            alert(t('panel.alert.configBadType'));
             return false;
         }
     }
@@ -866,7 +805,7 @@ function validateCustomCdn() {
     const isCustomCdn = customCdnAddrs.length || customCdnHost !== '' || customCdnSni !== '';
 
     if (isCustomCdn && !(customCdnAddrs.length && customCdnHost && customCdnSni)) {
-        alert('⛔ All "Custom" fields should be filled or deleted together!');
+        alert(t('panel.alert.cdnAllOrNone'));
         return false;
     }
 
@@ -878,11 +817,7 @@ function validateKnockerNoise() {
     const knockerNoise = getElmValue("knockerNoiseMode");
 
     if (!regex.test(knockerNoise)) {
-        alert(
-            '⛔ Invalid noise  mode.\n' +
-            '💡 Please use "none", "quic", "random" or a valid hex value.'
-        );
-
+        alert(t('panel.alert.invalidKnockerNoise'));
         return false;
     }
 
@@ -896,7 +831,7 @@ function validateXrayNoises(fields) {
 
     modes.forEach((mode, index) => {
         if (Number(delaysMin[index]) > Number(delaysMax[index])) {
-            alert('⛔ The minimum noise delay should be smaller or equal to maximum!');
+            alert(t('panel.alert.noiseDelayMinMax'));
             submisionError = true;
             return;
         }
@@ -904,7 +839,7 @@ function validateXrayNoises(fields) {
         switch (mode) {
             case 'base64': {
                 if (!base64Regex.test(packets[index])) {
-                    alert('⛔ The Base64 noise packet is not a valid base64 value!');
+                    alert(t('panel.alert.base64Invalid'));
                     submisionError = true;
                 }
 
@@ -912,14 +847,14 @@ function validateXrayNoises(fields) {
             }
             case 'rand': {
                 if (!(/^\d+-\d+$/.test(packets[index]))) {
-                    alert('⛔ The Random noise packet should be a range like 0-10 or 10-30!');
+                    alert(t('panel.alert.randInvalid'));
                     submisionError = true;
                 }
 
                 const [min, max] = packets[index].split("-").map(Number);
 
                 if (min > max) {
-                    alert('⛔ The minimum Random noise packet should be smaller or equal to maximum!');
+                    alert(t('panel.alert.randMinMax'));
                     submisionError = true;
                 }
 
@@ -927,10 +862,7 @@ function validateXrayNoises(fields) {
             }
             case 'hex': {
                 if (!(/^(?=(?:[0-9A-Fa-f]{2})*$)[0-9A-Fa-f]+$/.test(packets[index]))) {
-                    alert(
-                        '⛔ The Hex noise packet is not a valid hex value!\n' +
-                        '💡 It should have even length and consisted of 0-9, a-f and A-F.'
-                    );
+                    alert(t('panel.alert.hexInvalid'));
                     submisionError = true;
                 }
 
@@ -942,7 +874,7 @@ function validateXrayNoises(fields) {
                     .every(n => /^\d+$/.test(n) && +n >= 0 && +n <= 255);
 
                 if (!valid) {
-                    alert('⛔ The values should be comma separated numbers between 0-255');
+                    alert(t('panel.alert.arrayInvalid'));
                     submisionError = true;
                 }
 
@@ -958,7 +890,7 @@ function validateEchConfig() {
     const echServerName = getElmValue("echServerName");
 
     if (echServerName && !isDomain(echServerName)) {
-        alert('⛔ The ECH Server Name should be a domain!');
+        alert(t('panel.alert.echDomain'));
         return false;
     }
 
@@ -969,10 +901,7 @@ function validateUpstreamProxy() {
     const upstreamProxy = getElmValue('upstreamProxy');
 
     if (upstreamProxy && !isValidHostName(upstreamProxy, true)) {
-        alert(
-            '⛔ Invalid Upstream proxy!\n' +
-            '💡 It can be either IP:Port or Domain:Port'
-        );
+        alert(t('panel.alert.invalidUpstream'));
         return false;
     }
 
@@ -1083,7 +1012,7 @@ function resetPassword(event) {
     const confirmPassword = confirmPasswordInput.value;
 
     if (newPassword !== confirmPassword) {
-        passwordError.textContent = "Passwords do not match";
+        passwordError.textContent = t('panel.pwd.notMatch');
         return false;
     }
 
@@ -1092,7 +1021,7 @@ function resetPassword(event) {
     const isLongEnough = newPassword.length >= 8;
 
     if (!(hasCapitalLetter && hasNumber && isLongEnough)) {
-        passwordError.textContent = '⚠️ Password must contain at least one capital letter, one number, and be at least 8 characters long.';
+        passwordError.textContent = t('panel.pwd.weak');
         return false;
     }
 
@@ -1111,7 +1040,7 @@ function resetPassword(event) {
                 throw new Error(`status ${status} - ${message}`);
             }
 
-            alert("✅ Password changed successfully! 👍");
+            alert(t('panel.pwd.success'));
             window.location.href = '/login';
 
         })
@@ -1173,14 +1102,14 @@ function addUdpNoise(isManual, noiseIndex, udpNoise) {
 
     container.innerHTML = `
         <div class="header-container">
-            <h4>Noise ${index + 1}</h4>
+            <h4>${t('panel.warpPro.noiseLabel', { n: index + 1 })}</h4>
             <button type="button" class="delete-noise">
                 <span class="material-symbols-rounded">delete</span>
-            </button>      
+            </button>
         </div>
         <div class="section">
             <div class="form-control">
-                <label>😵‍💫 Mode</label>
+                <label>${t('panel.warpPro.noiseMode')}</label>
                 <div>
                     <select name="udpXrayNoiseMode">
                         <option value="base64" ${noise.type === 'base64' ? 'selected' : ''}>Base64</option>
@@ -1192,19 +1121,19 @@ function addUdpNoise(isManual, noiseIndex, udpNoise) {
                 </div>
             </div>
             <div class="form-control">
-                <label>📦 Packet</label>
+                <label>${t('panel.warpPro.packet')}</label>
                 <div>
                     <input type="text" name="udpXrayNoisePacket" value="${noise.packet}">
                 </div>
             </div>
             <div class="form-control">
-                <label>🎚️ Count</label>
+                <label>${t('panel.warpPro.count')}</label>
                 <div>
                     <input type="number" name="udpXrayNoiseCount" value="${noise.count}" min="1" required>
                 </div>
             </div>
             <div class="form-control">
-                <label>🕞 Delay</label>
+                <label>${t('panel.warpPro.delay')}</label>
                 <div class="min-max">
                     <input type="number" name="udpXrayNoiseDelayMin"
                         value="${noise.delay.split('-')[0]}" min="1" required>
@@ -1270,14 +1199,11 @@ function generateUdpNoise(event) {
 
 function deleteUdpNoise(event) {
     if (globalThis.xrayNoiseCount === 1) {
-        alert('⛔ You cannot delete all noises!');
+        alert(t('panel.alert.noiseDeleteAll'));
         return;
     }
 
-    const confirmReset = confirm(
-        '⚠️ This will delete the noise.\n\n' +
-        '❓ Are you sure?'
-    );
+    const confirmReset = confirm(t('panel.alert.noiseDeleteConfirm'));
 
     if (!confirmReset) return;
     event.target.closest(".inner-container").remove();

--- a/src/assets/panel/style.css
+++ b/src/assets/panel/style.css
@@ -712,6 +712,16 @@ body.dark-mode .floating-button:hover {
     transform: scale(1.1);
 }
 
+.floating-button.lang-toggle {
+    left: 90px;
+    color: var(--background-color);
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 60px;
+    text-align: center;
+    padding: 0;
+}
+
 .refresh-geo-location {
     background: none;
     margin: 0;

--- a/src/assets/proxy-ip/index.html
+++ b/src/assets/proxy-ip/index.html
@@ -21,24 +21,26 @@
     <table id="geo-table">
         <thead>
             <tr>
-                <th>#</th>
-                <th>Proxy IP</th>
-                <th>Country</th>
-                <th>City</th>
-                <th>ISP</th>
+                <th data-i18n="proxyIp.num"></th>
+                <th data-i18n="proxyIp.proxyIp"></th>
+                <th data-i18n="proxyIp.country"></th>
+                <th data-i18n="proxyIp.city"></th>
+                <th data-i18n="proxyIp.isp"></th>
             </tr>
         </thead>
         <tbody>
             <tr>
-                <td colspan="5">Loading...</td>
+                <td colspan="5" data-i18n="proxyIp.loading"></td>
             </tr>
         </tbody>
     </table>
+    <button id="langToggle" class="lang-toggle-fixed" onclick="toggleLang()">中</button>
 
     <script type="module" defer>
         import { polyfillCountryFlagEmojis } from "https://cdn.skypack.dev/country-flag-emoji-polyfill";
         polyfillCountryFlagEmojis();
     </script>
+    <script>__I18N__</script>
     <script>__SCRIPT__</script>
 </body>
 

--- a/src/assets/proxy-ip/script.js
+++ b/src/assets/proxy-ip/script.js
@@ -12,7 +12,7 @@ async function loadGeoData() {
         }
 
         if (!body.length) {
-            tableBody.innerHTML = "<tr><td colspan='5'>Failed to get Proxy IPs</td></tr>";
+            tableBody.innerHTML = `<tr><td colspan='5'>${t('proxyIp.failed')}</td></tr>`;
             return;
         }
 
@@ -41,13 +41,13 @@ async function loadGeoData() {
         });
 
     } catch (err) {
-        tableBody.innerHTML = `<tr><td colspan='5'>Error: ${err.message}</td></tr>`;
+        tableBody.innerHTML = `<tr><td colspan='5'>${t('proxyIp.error', { msg: err.message })}</td></tr>`;
         console.error(err);
     }
 }
 
 function copyToClipboard(text) {
     navigator.clipboard.writeText(text)
-        .then(() => alert('✅ Copied to clipboard:\n\n' + text))
+        .then(() => alert(t('panel.alert.copied', { text })))
         .catch(error => console.error('Failed to copy:', error));
 }

--- a/src/assets/proxy-ip/style.css
+++ b/src/assets/proxy-ip/style.css
@@ -86,3 +86,25 @@ td:nth-child(2) {
         'GRAD' 0,
         'opsz' 24
 }
+
+.lang-toggle-fixed {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: var(--color);
+    color: var(--background-color);
+    border: none;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transition: transform 0.3s;
+    z-index: 1000;
+}
+
+.lang-toggle-fixed:hover {
+    transform: scale(1.1);
+}

--- a/src/assets/secrets/index.html
+++ b/src/assets/secrets/index.html
@@ -22,13 +22,13 @@
         </h1>
         <div class="form-container">
             <div class="value-container">
-                <h2>Secrets generator</h2>
+                <h2 data-i18n="secrets.title"></h2>
                 <span class="material-symbols-rounded" onclick="generateCredentials()">
                     refresh
                 </span>
             </div>
             <div>
-                <h3>Random UUID</h3>
+                <h3 data-i18n="secrets.uuid"></h3>
                 <div class="value-container">
                     <div class="output-container">
                         <span id="uuid" class="output"></span>
@@ -39,7 +39,7 @@
                 </div>
             </div>
             <div>
-                <h3>Random Trojan Password</h3>
+                <h3 data-i18n="secrets.trPass"></h3>
                 <div class="value-container">
                     <div class="output-container">
                         <span id="tr-password" class="output"></span>
@@ -50,7 +50,7 @@
                 </div>
             </div>
             <div>
-                <h3>Random Subscription URI path</h3>
+                <h3 data-i18n="secrets.subPath"></h3>
                 <div class="value-container">
                     <div class="output-container">
                         <span id="sub-path" class="output"></span>
@@ -61,13 +61,15 @@
                 </div>
             </div>
             <button class="button" class="button" onclick="copyToClipboard()">
-                Copy all
+                <span data-i18n="common.copyAll"></span>
                 <span class="material-symbols-rounded">
                     content_copy
                 </span>
             </button>
         </div>
     </div>
+    <button id="langToggle" class="lang-toggle-fixed" onclick="toggleLang()">中</button>
+    <script>__I18N__</script>
     <script>__SCRIPT__</script>
 </body>
 

--- a/src/assets/secrets/script.js
+++ b/src/assets/secrets/script.js
@@ -47,6 +47,6 @@ window.copyToClipboard = function (elementId) {
         : `UUID=${uuid}\nTR_PASS=${password}\nSUB_PATH=${uriPath}`;
 
     navigator.clipboard.writeText(textToCopy)
-        .then(() => alert('✅ Copied to clipboard!'))
+        .then(() => alert(t('secrets.copied')))
         .catch(err => console.error('Failed to copy text:', err));
 }

--- a/src/assets/secrets/style.css
+++ b/src/assets/secrets/style.css
@@ -160,3 +160,25 @@ button {
         width: 40%;
     }
 }
+
+.lang-toggle-fixed {
+    position: fixed;
+    bottom: 20px;
+    right: 20px;
+    background-color: var(--color);
+    color: var(--background-color);
+    border: none;
+    border-radius: 50%;
+    width: 48px;
+    height: 48px;
+    font-size: 16px;
+    font-weight: 700;
+    cursor: pointer;
+    box-shadow: 0 4px 8px rgba(0, 0, 0, 0.2);
+    transition: transform 0.3s;
+    z-index: 1000;
+}
+
+.lang-toggle-fixed:hover {
+    transform: scale(1.1);
+}


### PR DESCRIPTION
- Bundle runtime dictionary via src/assets/i18n.js (zh/en)
- Auto-detect navigator.language on first visit, persist via localStorage
- Add floating language toggle on panel, login, secrets, and proxy-ip pages
- Mark static HTML with data-i18n attributes, route dynamic alerts and templates through t()
- Update build.js to inline i18n.js before page scripts