### PR TITLE
fix(auth): require authentication for panel and password reset on fresh deploys

### DIFF
--- a/src/auth.ts
+++ b/src/auth.ts
@@ -9,6 +9,10 @@ export async function generateJWTToken(request: Request, env: Env): Promise<Resp
     const password = await request.text();
     const savedPass = await env.kv.get('pwd');
 
+    if (!savedPass) {
+        return respond(false, HttpStatus.UNAUTHORIZED, 'Panel password is not set. Please set the `pwd` key in the Cloudflare KV namespace bound to this worker before logging in.');
+    }
+
     if (password !== savedPass) {
         return respond(false, HttpStatus.UNAUTHORIZED, 'Wrong password.');
     }
@@ -71,14 +75,15 @@ export async function Authenticate(request: Request, env: Env): Promise<boolean>
 }
 
 export async function resetPassword(request: Request, env: Env): Promise<Response> {
-    let auth = await Authenticate(request, env);
-    const oldPwd = await env.kv.get('pwd');
+    const auth = await Authenticate(request, env);
 
-    if (oldPwd && !auth) {
+    if (!auth) {
         return respond(false, HttpStatus.UNAUTHORIZED, 'Unauthorized.');
     }
 
+    const oldPwd = await env.kv.get('pwd');
     const newPwd = await request.text();
+
     if (newPwd === oldPwd) {
         return respond(false, HttpStatus.BAD_REQUEST, 'Please enter a new Password.');
     }

--- a/src/common/handlers.ts
+++ b/src/common/handlers.ts
@@ -398,14 +398,10 @@ export async function serveIcon(): Promise<Response> {
 }
 
 async function renderPanel(request: Request, env: Env): Promise<Response> {
-    const pwd = await env.kv.get('pwd');
-
-    if (pwd) {
-        const auth = await Authenticate(request, env);
-        if (!auth) {
-            const { urlOrigin } = globalThis.httpConfig;
-            return Response.redirect(`${urlOrigin}/login`, 302);
-        }
+    const auth = await Authenticate(request, env);
+    if (!auth) {
+        const { urlOrigin } = globalThis.httpConfig;
+        return Response.redirect(`${urlOrigin}/login`, 302);
     }
 
     const html = await decompressHtml(__PANEL_HTML_CONTENT__, false);


### PR DESCRIPTION
## Summary

This PR fixes an unauthenticated account-takeover vulnerability in the panel handlers (CWE-287, Improper Authentication). On a freshly deployed worker — i.e. before the operator has logged in for the first time and stored a password — any internet visitor who reached the worker URL could set the panel password and then log in as administrator, locking the legitimate operator out of their own deployment.

The relevant code paths are `renderPanel` and `resetPassword` in `src/common/handlers.ts` / `src/auth.ts`. Both contained a "first-run convenience" branch that skipped authentication when no `pwd` key existed in the bound KV namespace. Because Cloudflare Workers are internet-facing by design and the worker URL is published as part of the install flow, that window is reachable by anyone who learns the URL before the operator's first login completes.

## Vulnerability

- **Class:** CWE-287 — Improper Authentication / Missing Authentication for Critical Function
- **Affected functions:**
  - `renderPanel()` in `src/common/handlers.ts` (pre-fix: only called `Authenticate()` when `pwd` was already set)
  - `resetPassword()` in `src/auth.ts` (pre-fix: returned 401 only when `oldPwd && !auth`, i.e. allowed unauthenticated callers through when `pwd` was unset)
  - `generateJWTToken()` in `src/auth.ts` (pre-fix: did not reject an empty/null `savedPass` before the `password !== savedPass` comparison)
- **Preconditions:** network reach to the worker URL, and a worker in the fresh-deploy state (no `pwd` key yet in KV). No credentials, no session, no prior access required.
- **Impact:** Full administrative takeover of the panel. The attacker can set their own password, issue themselves a valid JWT, and modify any panel setting (proxy configs, Warp settings, sub links, etc.). The operator is locked out until they recover the KV key out-of-band.

### Data flow (pre-fix)

1. `GET /panel` → `handlePanel` → `renderPanel(request, env)`. With no `pwd` in KV the `if (pwd) { ... Authenticate ... }` block is skipped and the panel HTML is returned unauthenticated.
2. `POST /panel/reset-password` (body = attacker-chosen password) → `resetPassword(request, env)`. The guard was `if (oldPwd && !auth) return 401`. With `oldPwd === null` the guard is false and the handler writes `attacker_pwd` into `env.kv` via `env.kv.put('pwd', newPwd)` — this is the only `kv.put('pwd', ...)` site in the codebase (verified with `grep -rn "kv.put('pwd'" src/`).
3. `POST /login/authenticate` (body = same attacker-chosen password) → `generateJWTToken`. `savedPass` now equals the attacker's value, the equality check passes, and the worker returns a signed `jwtToken` cookie that grants admin access to every other `/panel/*` handler (`getSettings`, `updateSettings`, `resetSettings`, `updateWarpConfigs`, `getWarpConfigs`, etc., all of which call `Authenticate()`).

## Fix

Three surgical changes in `src/auth.ts` and `src/common/handlers.ts` (12 insertions, 11 deletions, no other files touched):

- `renderPanel` now **always** calls `Authenticate()` and redirects to `/login` on failure, regardless of whether `pwd` is set. The previous `if (pwd)` carve-out is removed.
- `resetPassword` now **always** requires a valid session. The `if (oldPwd && !auth)` guard becomes `if (!auth)`. `oldPwd` is still read afterwards so the "Please enter a new Password" same-password check still works.
- `generateJWTToken` now explicitly rejects login attempts when no password is configured, with a clear setup-required message:

  > Panel password is not set. Please set the `pwd` key in the Cloudflare KV namespace bound to this worker before logging in.

  This is defence-in-depth: even if some future caller bypasses `renderPanel`, an empty `savedPass` can no longer be coerced into matching a crafted password (e.g. an attacker submitting an empty body when `env.kv.get('pwd')` returns `null` — `'' !== null` would be true, but the explicit guard makes the intent unambiguous and robust to refactors).

The fix is **only** in the auth paths. None of the proxy / sub / Warp / config code is touched, so existing legitimate panel features behave identically once the operator is logged in.

### Operator UX note (recommend a docs follow-up)

After this fix, the worker requires the `pwd` key to exist in the bound KV namespace before login can succeed. The current `docs/en/docs/installation/workers-manual.md` flow ("It will ask you to set a new password and log in") will no longer work on a brand-new deployment because the unauthenticated password-set step is gone — that step was the vulnerability.

Two reasonable follow-ups for the maintainer to consider (not in this PR, since changing the install flow is your call):

1. Update the manual install docs to instruct operators to add a `pwd` entry via the Cloudflare KV dashboard before their first login, and surface the error message above when they hit `/login` too early.
2. Have BPB-Wizard (or a one-shot deploy script) write a strong random `pwd` at deploy time and display it once to the operator, so the user experience matches the old "set a password on first visit" flow but the password is never settable by an anonymous internet caller.

I'm happy to send a docs PR for option 1 if you'd like.

## Proof of Concept

The PoC below reproduces the attack against a vulnerable build (anything before this fix). All three URLs are real routes registered in `src/common/handlers.ts` — `case '/panel'` (line 47), `case '/panel/reset-password'` (line 59), and `if (pathName === '/login/authenticate')` (line 122).

Prerequisites: a freshly deployed BPB-Worker-Panel where the operator has not yet logged in for the first time, so the `pwd` key does not yet exist in the bound KV namespace. Replace `WORKER` with the worker URL.

```bash
WORKER="https://your-worker.workers.dev"

# 1. Fetch the panel HTML without any cookie. Pre-fix: returns 200 + full panel.
#    Post-fix: returns 302 -> /login.
curl -sS -o /dev/null -w "GET /panel  -> %{http_code}\n" "$WORKER/panel"

# 2. Set the panel password to "pwn" with no auth cookie. Pre-fix: 200 OK and
#    the KV 'pwd' key is now "pwn". Post-fix: 401 Unauthorized.
curl -sS -X POST --data "pwn" \
  -w "POST /panel/reset-password  -> %{http_code}\n" \
  "$WORKER/panel/reset-password"

# 3. Log in with the password we just set. Pre-fix: 200 OK and a jwtToken
#    cookie is set, granting admin access. Post-fix step 2 fails so this is
#    moot; if you skip step 2 and call this on a fresh worker directly, the
#    new explicit guard returns "Panel password is not set..." 401.
curl -sS -X POST --data "pwn" -c cookies.txt \
  -w "POST /login/authenticate  -> %{http_code}\n" \
  "$WORKER/login/authenticate"

# 4. With pre-fix, the jwtToken cookie from step 3 now authorises every
#    /panel/* endpoint. Demonstrate by reading settings:
curl -sS -b cookies.txt -o /dev/null \
  -w "GET /panel/settings  -> %{http_code}\n" \
  "$WORKER/panel/settings"
```

Pre-fix expected output:

```
GET /panel  -> 200
POST /panel/reset-password  -> 200
POST /login/authenticate  -> 200
GET /panel/settings  -> 200
```

Post-fix expected output:

```
GET /panel  -> 302   (redirected to /login)
POST /panel/reset-password  -> 401
POST /login/authenticate  -> 401   (body: "Panel password is not set...")
```

## What we tested

- Manual review of every `Authenticate()` caller in `src/common/handlers.ts` (8 sites at lines 77, 221, 241, 259, 319, 401, 414, 439) — all of them already check the boolean and 401/redirect on failure. The two pre-fix bypass sites were the only outliers.
- Searched the entire repo for other places that could write the `pwd` key: `grep -rn "kv.put('pwd'" src/` returns exactly one result, `src/auth.ts:91` inside `resetPassword`, which is now auth-gated. There is no other code path that mutates the password.
- Confirmed the routes referenced in the PoC exist as real cases in `handlePanel` / the parent router and that the panel UI's own `script.js` already calls them (`fetch('/panel/reset-password', ...)`, `fetch('/login/authenticate', ...)`), so the fix doesn't break any in-app flows for an authenticated user.
- TypeScript build passes with the patch applied; only `src/auth.ts` and `src/common/handlers.ts` are touched.

## Adversarial review

Before submitting, I tried to disprove this. The main objections worth checking:

1. *"Cloudflare Workers are private by default."* They aren't — once a worker is deployed it's served on `*.workers.dev` (or the operator's custom domain) and is reachable by anyone who learns the URL. The install docs ask the operator to open the worker URL in a browser, so the URL is not a meaningful secret.
2. *"The deploy flow runs faster than an attacker can race it."* The vulnerable window is open from the moment `wrangler publish` succeeds until the operator personally sets a password. That's typically minutes for a human operator, and the URL pattern is enumerable (`*.workers.dev` hostnames show up in TLS certificate transparency logs the moment a cert is issued). The race is realistic and one-shot — the attacker only has to win once per deployment.
3. *"`generateJWTToken` would refuse an empty password anyway because `password !== savedPass` ('' !== null is true)."* That's true in isolation, but the attack does not rely on the empty-password path — step 2 of the PoC writes an attacker-chosen non-empty value into KV first, so by the time step 3 runs `savedPass` is the attacker's value and the comparison succeeds. The explicit null check added in `generateJWTToken` is defence-in-depth, not the primary fix.
4. *"There must be some upstream auth (Cloudflare Access, etc.)."* No — the worker is the entire authentication surface for the panel. There is no router-level middleware in the codebase that gates `/panel` or `/login/authenticate`; the request dispatcher hands the request straight to `handlePanel` / the login handler with no prior auth check.

I could not find a mitigation that makes the pre-fix code safe on a fresh deploy, which is why this fix is worth landing.